### PR TITLE
Repair the speakers carousel on phones, add BRIDGE PASS badge

### DIFF
--- a/components/carousel.tsx
+++ b/components/carousel.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type React from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { EmblaOptionsType, EmblaCarouselType } from "embla-carousel";
 import useEmblaCarousel from "embla-carousel-react";
 import Autoplay from "embla-carousel-autoplay";
@@ -31,12 +31,75 @@ const Speakers: React.FC<PropType> = (props) => {
     autoplayDelay = 4000,
   } = props;
 
+  const rootRef = useRef<HTMLElement>(null);
+
+  /**
+   * Respect prefers-reduced-motion. Read once on mount rather than in render so
+   * server and first client paint agree; autoplay is a client-only concern.
+   */
+  const [reducedMotion, setReducedMotion] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReducedMotion(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
   const [emblaRef, emblaApi] = useEmblaCarousel(options, [
-    Autoplay({ delay: autoplayDelay, stopOnInteraction: false }),
+    Autoplay({
+      delay: autoplayDelay,
+      stopOnInteraction: false,
+      // Stop advancing while someone is reading or tabbing through a card.
+      stopOnMouseEnter: true,
+      stopOnFocusIn: true,
+    }),
   ]);
 
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [scrollSnaps, setScrollSnaps] = useState<number[]>([]);
+  const [isPlaying, setIsPlaying] = useState(true);
+
+  /**
+   * Auto-advancing content needs a way to stop it (WCAG 2.2.2).
+   *
+   * Intent is tracked separately from the plugin's own state. The plugin also
+   * stops itself on hover and focus, so a toggle that read `isPlaying()` would
+   * invert: pressing Pause while focus sat on a nav button found autoplay
+   * already stopped and started it instead.
+   */
+  const userPausedRef = useRef(false);
+
+  useEffect(() => {
+    const autoplay = emblaApi?.plugins()?.autoplay;
+    if (!autoplay || !reducedMotion) return;
+    userPausedRef.current = true;
+    autoplay.stop();
+    setIsPlaying(false);
+  }, [emblaApi, reducedMotion]);
+
+  // Hover-out and focus-out ask the plugin to resume. Honour the user's pause.
+  useEffect(() => {
+    const autoplay = emblaApi?.plugins()?.autoplay;
+    if (!emblaApi || !autoplay) return;
+    const enforce = () => {
+      if (userPausedRef.current) autoplay.stop();
+    };
+    emblaApi.on("autoplay:play", enforce);
+    return () => {
+      emblaApi.off("autoplay:play", enforce);
+    };
+  }, [emblaApi]);
+
+  const toggleAutoplay = useCallback(() => {
+    const autoplay = emblaApi?.plugins()?.autoplay;
+    if (!autoplay) return;
+    const pausing = !userPausedRef.current;
+    userPausedRef.current = pausing;
+    setIsPlaying(!pausing);
+    if (pausing) autoplay.stop();
+    else autoplay.play();
+  }, [emblaApi]);
 
   const onNavButtonClick = useCallback((emblaApi: EmblaCarouselType) => {
     const autoplay = emblaApi?.plugins()?.autoplay;
@@ -78,10 +141,20 @@ const Speakers: React.FC<PropType> = (props) => {
     emblaApi.on("reInit", onInit).on("reInit", onSelect).on("select", onSelect);
   }, [emblaApi, onInit, onSelect]);
 
+  /**
+   * Arrow keys move the carousel only while focus is inside it.
+   *
+   * This was bound to `document` and called preventDefault unconditionally, so
+   * pressing Left or Right anywhere on the page scrolled the carousel and ate
+   * the keystroke — including caret movement inside form fields.
+   */
   useEffect(() => {
-    if (!emblaApi) return;
+    const root = rootRef.current;
+    if (!emblaApi || !root) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey)
+        return;
       if (event.key === "ArrowLeft") {
         event.preventDefault();
         emblaApi.scrollPrev();
@@ -91,18 +164,19 @@ const Speakers: React.FC<PropType> = (props) => {
       }
     };
 
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    root.addEventListener("keydown", handleKeyDown);
+    return () => root.removeEventListener("keydown", handleKeyDown);
   }, [emblaApi]);
 
   return (
     <section
+      ref={rootRef}
       className={`embla w-full flex items-center justify-center flex-col relative ${className}`}
       // biome-ignore lint/a11y/noRedundantRoles: <explanation>
       // biome-ignore lint/a11y/useSemanticElements: <explanation>
       role="region"
       aria-label="Speaker carousel"
-      aria-live="polite"
+      aria-roledescription="carousel"
     >
       {/* Navigation Buttons - Positioned absolutely */}
       <div className="hidden lg:block absolute inset-0 pointer-events-none">
@@ -133,7 +207,9 @@ const Speakers: React.FC<PropType> = (props) => {
         <div className="flex touch-pan-y touch-pinch-zoom">
           {speakers.map((speaker, index) => (
             <div
-              className="md:flex-[0_0_75%] flex-[0_0_50%] lg:flex-[0_0_90%] xl:flex-[0_0_100%] min-w-0 flex items-stretch justify-center px-2 md:px-8"
+              // Phones get one card, near full width. At 50% the card content
+              // box was 91px and everything inside it overflowed.
+              className="flex-[0_0_88%] md:flex-[0_0_75%] lg:flex-[0_0_90%] xl:flex-[0_0_100%] min-w-0 flex items-stretch justify-center px-1.5 md:px-8"
               key={`${speaker.name}-${index}`}
               // biome-ignore lint/a11y/useSemanticElements: <explanation>
               role="group"
@@ -147,21 +223,32 @@ const Speakers: React.FC<PropType> = (props) => {
               >
                 <div className="mx-auto flex h-full w-full max-w-4xl flex-col justify-center rounded-xl border border-white/20 bg-white/5 p-6 transition-colors duration-300 hover:bg-white/10 md:p-8">
                   <div className="flex items-center justify-center md:justify-between gap-6 flex-col-reverse md:flex-row text-center md:text-left">
-                    <div className="flex min-w-0 flex-1 basis-full flex-col items-center text-white md:basis-[60%] md:items-start">
-                      <h2 className="text-2xl md:text-3xl xl:text-5xl font-bold uppercase tracking-tight leading-tight">
+                    {/* basis-0 + flex-1 so the text takes whatever the portrait
+                        leaves. The old md:basis-[60%] against the portrait's
+                        42% over-committed the row by 8% plus the gap. */}
+                    <div className="flex w-full min-w-0 flex-1 basis-full flex-col items-center text-white md:w-auto md:basis-0 md:items-start">
+                      {/* 3xl moved from md to lg: at 768px the widest names were
+                          wider than their own column. */}
+                      <h2 className="text-xl min-[360px]:text-2xl lg:text-3xl xl:text-5xl font-bold uppercase tracking-tight leading-tight break-words">
                         {speaker.name}
                       </h2>
                       <p className="mt-3 text-sm md:text-lg xl:text-2xl leading-relaxed text-white/60 md:mt-4">
                         {speaker.title}
                       </p>
                     </div>
-                    <div className="md:basis-[40%] basis-auto w-[250px] h-[250px]  md:w-[250px] md:h-[250px] lg:w-[300px] lg:h-[300px]  xl:w-[350px] xl:h-[350px] aspect-square rounded-xl overflow-hidden border border-white/20 flex-shrink-0 mx-auto md:mx-0">
+                    {/* Sized fluidly and capped, never pinned. The old fixed
+                        250px frame was wider than the card that held it, so the
+                        portrait spilled across its neighbours on phones. Height
+                        comes from aspect-square, so the frame is always square:
+                        the previous fixed w/h pairs fought basis-[40%] and left
+                        it 147x238 at md and 315x333 at xl. */}
+                    <div className="basis-auto w-full max-w-[240px] md:basis-[46%] md:w-auto md:max-w-[300px] xl:max-w-[340px] aspect-square shrink-0 overflow-hidden rounded-xl border border-white/20 mx-auto md:mx-0">
                       <Image
                         src={speaker.image}
                         alt={`Portrait of ${speaker.name}, ${speaker.title}`}
                         width={640}
                         height={640}
-                        sizes="(max-width: 640px) 250px, (max-width: 768px) 250px, (max-width: 1024px) 300px, (max-width: 1280px) 320px, 320px"
+                        sizes="(max-width: 767px) 240px, (max-width: 1279px) 300px, 340px"
                         className="w-full h-full object-cover object-center transition-transform duration-300 group-hover:scale-105"
                         style={{ objectPosition: "center 15%" }}
                         // Only the first slide is above the fold; the rest wait.
@@ -179,10 +266,12 @@ const Speakers: React.FC<PropType> = (props) => {
 
       {/* Dot Indicators */}
       {showDots && scrollSnaps.length > 1 && (
+        // Plain buttons in a group, not a tablist: there are no tabpanels here,
+        // and the tab pattern promises a keyboard model this does not implement.
         <div
           className="hidden md:flex justify-center gap-2 mt-5"
-          role="tablist"
-          aria-label="Speaker slides"
+          role="group"
+          aria-label="Choose speaker slide"
         >
           {scrollSnaps.map((_, index) => (
             <button
@@ -192,8 +281,7 @@ const Speakers: React.FC<PropType> = (props) => {
               // The dot stays 12px; the hit area around it is a full 44px.
               className="flex min-h-11 w-6 shrink-0 items-center justify-center"
               onClick={() => scrollTo(index)}
-              role="tab"
-              aria-selected={index === selectedIndex}
+              aria-current={index === selectedIndex}
               aria-label={`Go to slide ${index + 1}: ${speakers[index]?.name}`}
             >
               <span
@@ -207,20 +295,40 @@ const Speakers: React.FC<PropType> = (props) => {
         </div>
       )}
 
-      {/* Mobile Navigation Buttons - Below the card */}
-      <div className="block lg:hidden w-full mt-4">
-        <div className="flex justify-center gap-4">
+      {/* Below-card controls. Dots don't fit on a phone with 12 slides, so
+          phones get a counter instead and are otherwise left with no sense of
+          position at all. */}
+      <div className="mt-4 flex w-full items-center justify-center gap-4">
+        <div className="flex items-center gap-4 lg:hidden">
           <PrevButton
             onClick={onPrevButtonClick}
             disabled={prevBtnDisabled}
             className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full border border-white/20 bg-white/10 text-white transition-colors duration-300 hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-50"
           />
+          {scrollSnaps.length > 1 && (
+            <p className="text-sm tabular-nums text-white/60 md:hidden">
+              <span className="sr-only">Slide </span>
+              {selectedIndex + 1} of {scrollSnaps.length}
+            </p>
+          )}
           <NextButton
             onClick={onNextButtonClick}
             disabled={nextBtnDisabled}
             className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full border border-white/20 bg-white/10 text-white transition-colors duration-300 hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-50"
           />
         </div>
+
+        {!reducedMotion && (
+          <button
+            type="button"
+            onClick={toggleAutoplay}
+            aria-pressed={!isPlaying}
+            className="flex h-11 min-w-11 cursor-pointer items-center justify-center rounded-full border border-white/20 px-4 text-xs font-semibold text-white/60 transition-colors duration-300 hover:bg-white/10 hover:text-white"
+          >
+            {isPlaying ? "Pause" : "Play"}
+            <span className="sr-only"> automatic slideshow</span>
+          </button>
+        )}
       </div>
     </section>
   );

--- a/components/carouselbuttons.tsx
+++ b/components/carouselbuttons.tsx
@@ -19,8 +19,8 @@ export const usePrevNextButtons = (
   emblaApi: EmblaCarouselType | undefined,
   onButtonClick?: (emblaApi: EmblaCarouselType) => void
 ): UsePrevNextButtonsType => {
-  const [prevBtnDisabled, setPrevBtnDisabled] = useState(true);
-  const [nextBtnDisabled, setNextBtnDisabled] = useState(true);
+  const [prevBtnDisabled, setPrevBtnDisabled] = useState(false);
+  const [nextBtnDisabled, setNextBtnDisabled] = useState(false);
 
   const onPrevButtonClick = useCallback(() => {
     if (!emblaApi) return;
@@ -61,16 +61,21 @@ export const PrevButton: React.FC<PropType> = (props) => {
 
   return (
     <button
-      className="appearance-none bg-white touch-manipulation inline-flex cursor-pointer border-0 p-0 m-0 shadow-inner md:w-[44px] w-[40px] md:h-[44px] h-[40px] z-10 rounded-full  items-center justify-center text-nano-secondary disabled:text-nano-lightSecondary embla__button--prev"
+      className="appearance-none touch-manipulation inline-flex cursor-pointer border-0 p-0 m-0 min-w-11 min-h-11 z-10 rounded-full items-center justify-center embla__button--prev"
       type="button"
+      aria-label="Previous speaker"
       {...restProps}
     >
-      <svg className="w-[25%] h-[25%]" viewBox="0 0 532 532">
+      <svg
+        className="w-[25%] h-[25%]"
+        viewBox="0 0 532 532"
+        aria-hidden="true"
+        focusable="false"
+      >
         <path
           fill="currentColor"
           d="M355.66 11.354c13.793-13.805 36.208-13.805 50.001 0 13.785 13.804 13.785 36.238 0 50.034L201.22 266l204.442 204.61c13.785 13.805 13.785 36.239 0 50.044-13.793 13.796-36.208 13.796-50.002 0a5994246.277 5994246.277 0 0 0-229.332-229.454 35.065 35.065 0 0 1-10.326-25.126c0-9.2 3.393-18.26 10.326-25.2C172.192 194.973 332.731 34.31 355.66 11.354Z"
         />
-        <title> carousel</title>
       </svg>
       {children}
     </button>
@@ -82,12 +87,17 @@ export const NextButton: React.FC<PropType> = (props) => {
 
   return (
     <button
-      className="appearance-none bg-white touch-manipulation inline-flex cursor-pointer border-0 p-0 m-0 shadow-inner md:w-[44px] w-[40px] md:h-[44px] h-[40px] z-10 rounded-full  items-center justify-center text-nano-secondary disabled:text-nano-lightSecondary embla__button--next"
+      className="appearance-none touch-manipulation inline-flex cursor-pointer border-0 p-0 m-0 min-w-11 min-h-11 z-10 rounded-full items-center justify-center embla__button--next"
       type="button"
+      aria-label="Next speaker"
       {...restProps}
     >
-      <svg className="w-[25%] h-[25%]" viewBox="0 0 532 532">
-        <title> carousel</title>
+      <svg
+        className="w-[25%] h-[25%]"
+        viewBox="0 0 532 532"
+        aria-hidden="true"
+        focusable="false"
+      >
         <path
           fill="currentColor"
           d="M176.34 520.646c-13.793 13.805-36.208 13.805-50.001 0-13.785-13.804-13.785-36.238 0-50.034L330.78 266 126.34 61.391c-13.785-13.805-13.785-36.239 0-50.044 13.793-13.796 36.208-13.796 50.002 0 22.928 22.947 206.395 206.507 229.332 229.454a35.065 35.065 0 0 1 10.326 25.126c0 9.2-3.393 18.26-10.326 25.2-45.865 45.901-206.404 206.564-229.332 229.52Z"

--- a/components/home/speakers.tsx
+++ b/components/home/speakers.tsx
@@ -38,7 +38,7 @@ export function SpeakersSection() {
         </div>
 
         {/* 2026 Speaker CTA */}
-        <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="mt-10 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-lg text-white/90">
             Want to speak at Blockf3st Africa 2026?
           </p>

--- a/components/home/sponsorship.tsx
+++ b/components/home/sponsorship.tsx
@@ -50,10 +50,10 @@ export function SponsorshipSection() {
               onClick={() =>
                 trackButtonClick("Email Sponsorship", "Sponsorship Section")
               }
-              className="inline-flex min-h-12 max-w-full items-center justify-center gap-2 rounded-full bg-brand-gold px-7 text-sm font-semibold text-black transition-colors duration-300 hover:bg-brand-gold-hover sm:text-base"
+              className="inline-flex min-h-12 max-w-full items-center justify-center gap-2 rounded-full bg-brand-gold px-4 py-2 text-sm font-semibold text-black transition-colors duration-300 hover:bg-brand-gold-hover sm:px-7 sm:text-base"
             >
               <Mail className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
-              <span className="truncate">{contactEmail}</span>
+              <span className="break-all text-center">{contactEmail}</span>
             </Link>
             <span className="self-center text-sm text-white/60">or</span>
             <Link

--- a/components/home/tickets-2026.tsx
+++ b/components/home/tickets-2026.tsx
@@ -76,13 +76,18 @@ export function Tickets2026Section() {
                   {tiers.map((tier) => (
                     <li
                       key={tier.id}
-                      className="flex items-center gap-2 text-sm text-white/60"
+                      className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-white/60"
                     >
                       <Check
                         className="h-4 w-4 shrink-0 text-brand-blue-light"
                         aria-hidden="true"
                       />
                       {tier.name}
+                      {tier.bestSeller && (
+                        <span className="rounded-full bg-brand-gold px-2 py-0.5 text-[0.625rem] font-bold uppercase tracking-wide text-black">
+                          Best seller
+                        </span>
+                      )}
                     </li>
                   ))}
                 </ul>

--- a/components/shared/footer.tsx
+++ b/components/shared/footer.tsx
@@ -155,7 +155,9 @@ const Footer = () => {
         <div className="border-t border-white/20" />
       </div>
 
-      <div className="container-page py-6 flex flex-col sm:flex-row items-center justify-between gap-3">
+      {/* pb-20 reserves room for the fixed back-to-top button, which sat on
+          the end of the copyright line. */}
+      <div className="container-page py-6 pb-20 lg:pb-6 flex flex-col sm:flex-row items-center justify-between gap-3">
         <p className="text-nav-gray/60 text-sm order-2 sm:order-1">
           © {currentYear} Blockfest Africa. All rights reserved.
         </p>

--- a/lib/tickets.ts
+++ b/lib/tickets.ts
@@ -73,6 +73,8 @@ export interface TicketTier {
   includes: string[];
   /** Stated plainly on the card. A day-limited pass must say what it is not. */
   excludes?: string[];
+  /** Sells the most. Distinct from `featured`, which marks the pick of a group. */
+  bestSeller?: boolean;
   bestFor: string;
   /** Highlighted as the recommended pick within its group. */
   featured?: boolean;
@@ -119,6 +121,7 @@ export const ticketTiers: TicketTier[] = [
   {
     id: "bridge-pass",
     name: "BRIDGE PASS",
+    bestSeller: true,
     group: "conference",
     price: 15_000,
     standardPrice: 20_000,


### PR DESCRIPTION
The homepage speakers carousel was unreadable on a phone.

## What was wrong

Three faults compounded:

- The slide was `flex-[0_0_50%]`, so at 375px the card inside it had a **91px content box**.
- The portrait in that card was pinned to `w-[250px] h-[250px]` with `flex-shrink-0` — **158px wider than the card holding it** — so it spilled across the neighbouring slides.
- Speaker names overflowed their column too.

The result was three half-cards with photographs and text stacked on top of each other.

Squareness was broken independently: the fixed `w-`/`h-` pairs fought `md:basis-[40%]`, leaving the "aspect-square" frame at **147×238 at 768px** and **315×333 at 1280px**.

## The fix

Slides are 88% on phones — one card with a peek edge. The portrait is `w-full max-w-[240px]` with its height derived from `aspect-square`, so it can never exceed its card. The text column moves to `basis-0 flex-1`, because `basis-[60%]` against the portrait's basis over-committed the row.

Measured across ten widths from 320 to 1536px: **portrait overflow 0 everywhere, no name escapes its column, frame square at every width.**

| width | slide | card | portrait |
|---|---|---|---|
| 320 | 214 | 203 | 155×155 |
| 375 | 260 | 249 | 201×201 |
| 390 | 273 | 261 | 214×214 |
| 768 | 490 | 429 | 169×169 |
| 1280 | 988 | 851 | 323×323 |

## Behaviour bugs found while measuring

- **Arrow keys were hijacked page-wide.** The handler was bound to `document` and called `preventDefault` unconditionally, so Left/Right anywhere on the page scrolled the carousel and swallowed the keystroke — including caret movement inside form fields. Now scoped to the carousel, and ignores modifier combinations.
- **Both nav buttons announced as "carousel".** Their only accessible name came from an identical `<title> carousel</title>` inside the icon. Now labelled "Previous speaker" / "Next speaker" with `aria-hidden` icons.
- **Autoplay could not be stopped** (WCAG 2.2.2 failure). Added a pause control, `stopOnMouseEnter`/`stopOnFocusIn`, and no autoplay at all under `prefers-reduced-motion`. The pause tracks user intent separately from plugin state — reading `isPlaying()` inverted the button, because the plugin had already stopped itself on focus.
- **`aria-live="polite"` wrapped an autoplaying region.** Removed, `aria-roledescription="carousel"` in its place.
- **Dots used tab/tablist with no tabpanel.** Now a plain group with `aria-current`. Phones, which get no dots, now get a "1 of 12" counter — with 12 slides they previously had no sense of position at all.
- **Nav buttons shipped SSR-disabled** at 50% opacity, under `loop: true` where they can never legitimately be disabled.

## Also on the homepage

- **BRIDGE PASS carries a "Best seller" badge**, driven by a `bestSeller` flag on the tier so the badge cannot drift from the data.
- The sponsorship CTA **truncated the email address it exists to display**.
- The speakers CTA stretched full width on phones, unlike the equivalent tickets CTA, and the fixed back-to-top button landed on its end. The footer now reserves room under that button too.

## Verification

Against a production build, not the dev server:

- 52/52 static pages, biome clean, `tsc --noEmit` clean
- layout assertions pass at 320/360/375/390/412/640/768/1024/1280/1536
- arrow keys outside the carousel no longer move it; inside, they still do
- pause stops autoplay for 6s and play resumes it
- `prefers-reduced-motion` never starts autoplay
- every route still 200

Note: `html { overflow-x: hidden }` in globals.css masks this class of bug from page-level `scrollWidth` checks, which is why it survived earlier audits. The assertions here measure each element against its parent instead.
