### PR TITLE
Make every mobile menu item reachable and tappable

### DIFF
--- a/components/shared/navbar.tsx
+++ b/components/shared/navbar.tsx
@@ -190,7 +190,14 @@ const Navbar = () => {
                 <BurgerIcon className="text-white" />
               </button>
             </SheetTrigger>
-            <SheetContent side="top">
+            {/* The panel grows with its content and is fixed, so on a short
+                viewport the lower items were unreachable. Cap it and let it
+                scroll. This has to land with the taller tap targets below,
+                which push the panel further past the fold. */}
+            <SheetContent
+              side="top"
+              className="max-h-[100dvh] overflow-y-auto overscroll-contain"
+            >
               <MobileMenu />
             </SheetContent>
           </Sheet>
@@ -224,7 +231,7 @@ const MobileMenu = () => {
 
   return (
     <div
-      className={`${gotham.className} px-6 py-8 flex flex-col h-full bg-ground`}
+      className={`${gotham.className} px-6 py-8 flex min-h-full flex-col bg-ground`}
     >
       {/* Close Button */}
       <div className="flex justify-end mb-8">
@@ -271,7 +278,7 @@ const MobileMenu = () => {
             type="button"
             onClick={() => setPastEventsOpen((open) => !open)}
             aria-expanded={pastEventsOpen}
-            className="text-lg font-medium text-nav-gray hover:text-white transition w-fit inline-flex items-center gap-1.5"
+            className="text-lg font-medium text-nav-gray hover:text-white transition w-fit min-h-11 inline-flex items-center gap-1.5"
           >
             Past Events
             <ChevronDown
@@ -285,7 +292,7 @@ const MobileMenu = () => {
               <SheetClose asChild>
                 <Link
                   href="/blockfest-south-africa-2026"
-                  className="text-base font-medium text-nav-gray hover:text-white hover:underline transition w-fit inline-flex items-center gap-1.5"
+                  className="text-base font-medium text-nav-gray hover:text-white hover:underline transition w-fit min-h-11 inline-flex items-center gap-1.5"
                 >
                   South Africa &apos;26
                 </Link>
@@ -293,7 +300,7 @@ const MobileMenu = () => {
               <SheetClose asChild>
                 <Link
                   href="/blockfest-2025"
-                  className="text-base font-medium text-nav-gray hover:text-white hover:underline transition w-fit inline-flex items-center gap-1.5"
+                  className="text-base font-medium text-nav-gray hover:text-white hover:underline transition w-fit min-h-11 inline-flex items-center gap-1.5"
                 >
                   2025 Recap
                 </Link>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -70,10 +70,11 @@ function SheetContent({
         )}
         {...props}
       >
+        {/* No default close button. The upstream one holds only an sr-only
+            span with no icon, so it renders 0x0 — a keyboard-focusable control
+            nobody can see or tap, sitting on top of the visible close the
+            content already provides. Sheets supply their own SheetClose. */}
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus-visible:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-md opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none">
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
       </SheetPrimitive.Content>
     </SheetPortal>
   )


### PR DESCRIPTION
Both halves of this ship together, as flagged in #13 — the tap-target fix alone makes the reachability problem worse.

## Reachability

The menu panel is fixed-position and sized `h-auto`, so it grew to **657px regardless of the viewport**. With `overflow-y: visible` and no scroll, anything past the fold was unreachable:

| viewport | items below the fold, before |
|---|---|
| 320×454 (iPhone SE 1st) | 3 |
| 375×553 (iPhone SE 2/3) | 1 |
| 740×360 (landscape) | 4 |

The panel is now capped at `100dvh` and scrolls, with `overscroll-contain` so the page behind doesn't scroll with it. `dvh` rather than `vh` because mobile browser chrome shrinks the visual viewport. The inner wrapper moves from `h-full` to `min-h-full` so it grows past the panel instead of fighting it.

## Tap targets

The **Past Events** toggle measured **28px** against the 44px minimum, and its two sub-links were untargeted too. Every other item in the menu already carried `min-h-11`.

This is why the two changes are one commit: adding `min-h-11` to three controls makes the panel taller, which would have pushed *more* items out of reach on its own.

## Bonus defect found while measuring

`SheetContent` rendered a default close button containing only an `sr-only` span and no icon, so it was **0×0** — a keyboard-focusable control nobody can see or tap, sitting on top of the visible 44×44 close the menu already provides. Removed; sheets supply their own `SheetClose`. `side="top"` is used only by this menu, so nothing else is affected.

## Verification

Against a production build at 320×454, 375×553, 375×629, 390×664, 412×733 and 740×360, with the Past Events accordion expanded so the tallest state is measured:

- no tap target under 44px
- on every constrained viewport the last item is **off-screen before scrolling, in view after, clickable, and navigation actually fires**
- desktop nav unchanged: burger stays hidden, dropdown opens, 2 menu items
- carousel assertions from #13 still pass, biome and tsc clean, 52/52 pages
