### PR TITLE
Rename the AI & Crypto track to AI & Blockchain

### DIFF
--- a/lib/events.ts
+++ b/lib/events.ts
@@ -232,7 +232,7 @@ export const blockfest2026Lagos: BlockfestEvent = {
 // Lagos '26 programming tracks (deck: "What We'll Be Talking About").
 export const lagos2026Tracks: EventTrack[] = [
   {
-    title: "AI & Crypto",
+    title: "AI & Blockchain",
     description:
       "Where intelligence meets ownership. Exploring the convergence reshaping the next decade.",
   },


### PR DESCRIPTION
One-line copy change in `lib/events.ts`, the single source for the homepage tracks.

Verified in a production build: the homepage renders "AI & Blockchain" and no longer contains "AI & Crypto". 52/52 pages, biome and tsc clean.

Left alone deliberately: "crypto" in speaker bios (their own words) and in SEO keyword lists across `app/*/page.tsx` — people search that term, so removing it would cost discoverability.