### PR TITLE
Show the Best seller badge on the tickets page

### DIFF
--- a/components/tickets/ticket-tiers.tsx
+++ b/components/tickets/ticket-tiers.tsx
@@ -11,15 +11,26 @@ function TierCard({ tier }: { tier: TicketTier }) {
   return (
     <div
       className={`relative flex flex-col rounded-xl border p-6 transition-colors duration-300 ${
-        tier.featured
+        tier.featured || tier.bestSeller
           ? "border-brand-blue bg-white/10 hover:bg-white/20"
           : "border-white/20 bg-white/5 hover:bg-white/20"
       }`}
     >
-      {tier.featured && (
-        <span className="eyebrow absolute -top-3 left-6 rounded-full bg-brand-gold px-3 py-1 text-black">
-          Most popular
-        </span>
+      {/* A row rather than one absolute badge, so a tier carrying both labels
+          sets them side by side instead of stacking them on top of each other. */}
+      {(tier.featured || tier.bestSeller) && (
+        <div className="absolute -top-3 left-6 right-6 flex flex-wrap items-center gap-2">
+          {tier.featured && (
+            <span className="eyebrow rounded-full bg-brand-gold px-3 py-1 text-black">
+              Most popular
+            </span>
+          )}
+          {tier.bestSeller && (
+            <span className="eyebrow rounded-full bg-brand-blue px-3 py-1 text-white">
+              Best seller
+            </span>
+          )}
+        </div>
       )}
 
       <h3 className="text-lg font-bold text-white lg:text-2xl">{tier.name}</h3>


### PR DESCRIPTION
BRIDGE PASS already carried the `bestSeller` flag and showed the badge in the homepage summary, but `/tickets` — where people actually choose — did not render it.

## What changed

- **Badges render in a flex row** rather than as one absolutely positioned span, so a tier carrying both labels sets them side by side instead of stacking them on top of each other.
- **Blue badge** to separate it from the gold "Most popular". White on `--color-brand-blue` measures **5.26:1**, clearing AA for normal text.
- The card takes the same emphasised border the featured cards use, so the badge does not float on an otherwise plain card.

## Verification

Production build at 375, 768 and 1280px:

- "Best seller" appears exactly once, on BRIDGE PASS
- "Most popular" still on BECOME PASS, BECOME PLUS, ALL ACCESS PASS
- no badge clipped or escaping its card at any width, 0px page overflow
- 52/52 pages, biome and tsc clean

## One thing worth a look

BRIDGE PASS ("Best seller") and BECOME PASS ("Most popular") sit in the same Conference Day group, and those two phrases read as near-synonyms to a buyer. It is clear if the intent is "this one sells the most volume, this one is our recommendation" — less so at a glance. Easy to change either label or drop one if you would rather.

The CTA button is untouched: gold is still keyed to `featured`, so BRIDGE PASS keeps the outline button. Say the word if the best seller should take the prominent CTA instead.