### PR TITLE
Spell out what every pass includes, and lead each card with its days

### DIFF
--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -44,7 +44,9 @@ export function GET() {
           const excludes = t.excludes?.length
             ? ` Does not include ${t.excludes.map((x) => x.charAt(0).toLowerCase() + x.slice(1)).join(", ")}.`
             : "";
-          return `  - ${t.name} — ${price}. ${t.days.join("; ")}. ${t.bestFor}${excludes}`;
+          const days = t.days.map((d) => `${d.label} (${d.date})`).join("; ");
+          const note = t.note ? ` ${t.note}` : "";
+          return `  - ${t.name} — ${price}. ${days}. ${t.bestFor}${excludes}${note}`;
         })
         .join("\n");
       return `${group.title}: ${group.description}\n${rows}`;
@@ -64,8 +66,11 @@ export function GET() {
 - Venue: ${e.location.venue}, ${e.location.country}
 - Expected attendance: 5,000+ founders, engineers, investors, creators, corporate
   leaders, policymakers and emerging talent
-- Format: in person. Day 1 workshops and The Back Room, Day 2 main conference and
-  exhibition, Day 3 industry mixer.
+- Format: in person. Day 1 (Thu 22 Oct) workshops and The Back Room, Day 2
+  (Fri 23 Oct) main conference and exhibition, Day 3 (Sat 24 Oct) the Mixer.
+- Days 1 and 2 are open to anyone with a ticket. Day 3, the Mixer, is invitation
+  only and is not sold separately: speakers, invited guests, partners and KOLs
+  are admitted automatically, and the ALL ACCESS PASS also includes it.
 - Official ticket platform: ${TICKET_PLATFORM_URL}
 
 ## Tickets

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -44,7 +44,7 @@ export function GET() {
           const excludes = t.excludes?.length
             ? ` Does not include ${t.excludes.map((x) => x.charAt(0).toLowerCase() + x.slice(1)).join(", ")}.`
             : "";
-          return `  - ${t.name} — ${price}. ${t.days}. ${t.bestFor}${excludes}`;
+          return `  - ${t.name} — ${price}. ${t.days.join("; ")}. ${t.bestFor}${excludes}`;
         })
         .join("\n");
       return `${group.title}: ${group.description}\n${rows}`;

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -1,9 +1,9 @@
-import { Agenda } from "@/components/agenda";
+import { PastAgenda } from "@/components/schedule/past-agenda";
 import { gotham } from "@/lib/fonts";
 import type { Metadata } from "next";
 import { BaseSchema } from "@/components/seo/schema-markup";
 import { ComingSoonNotice } from "@/components/shared/coming-soon-notice";
-import { EVENT_ID } from "@/lib/seo-event";
+import { EVENT_ID, CURRENT_EDITION } from "@/lib/seo-event";
 
 export const metadata: Metadata = {
   title: "Schedule | Blockfest Africa - Event Program & Activities",
@@ -39,7 +39,7 @@ export default function Schedule() {
   };
 
   const schedulePageData = {
-    name: "Schedule - Blockfest Africa 2025",
+    name: `Schedule - ${CURRENT_EDITION.name}`,
     description:
       "The Lagos '26 three-day programme is published in the coming weeks. Meanwhile, see how the 2025 edition ran: keynotes, workshops, panels and networking.",
     url: "https://blockfestafrica.com/schedule",
@@ -49,10 +49,12 @@ export default function Schedule() {
       url: "https://blockfestafrica.com",
     },
     about: { "@id": EVENT_ID },
+    // The page is about the current edition. It said 2025, which told crawlers
+    // this route was last year's programme.
     mainEntity: {
       "@type": "EventSchedule",
-      name: "Blockfest Africa 2025 Schedule",
-      description: "Complete program of activities for Blockfest Africa 2025",
+      name: `${CURRENT_EDITION.name} Schedule`,
+      description: `Programme of activities for ${CURRENT_EDITION.name} on ${CURRENT_EDITION.date.displayDate}. Times are published closer to the event.`,
     },
   };
 
@@ -66,14 +68,14 @@ export default function Schedule() {
       <main id="main" className={`${gotham.className} min-h-screen bg-paper`}>
         <ComingSoonNotice
           title="2026 schedule coming soon"
-          description="The three-day Lagos '26 programme is published in the coming weeks. The 2025 schedule is below."
+          description="The Lagos '26 programme is published in the coming weeks. October 22 is the workshop and The Back Room, October 23 the main conference, October 24 the invitation-only Mixer."
         />
 
         {/* Header Section */}
         <section className="section-y bg-ground">
           <div className="container-page">
             <div className="max-w-2xl">
-              <p className="eyebrow text-white/60">2025 SCHEDULE</p>
+              <p className="eyebrow text-white/60">Lagos &apos;26</p>
               <h1
                 id="schedule-heading"
                 className="text-display-sm mt-3 font-bold text-white"
@@ -81,7 +83,9 @@ export default function Schedule() {
                 Schedule of <span className="text-white">Activities</span>
               </h1>
               <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
-                How the 2025 edition ran, hour by hour.
+                Times for October 22 to 24 land in the coming weeks.
+                Last year&apos;s programme is a good guide to the shape of the
+                days.
               </p>
             </div>
           </div>
@@ -89,7 +93,7 @@ export default function Schedule() {
 
         <section className="section-y bg-paper">
           <div className="container-page">
-            <Agenda />
+            <PastAgenda />
           </div>
         </section>
       </main>

--- a/components/schedule/past-agenda.tsx
+++ b/components/schedule/past-agenda.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { Agenda } from "@/components/agenda";
+
+/**
+ * Last year's agenda, collapsed.
+ *
+ * /schedule answers "when is what in 2026", and the answer today is "not
+ * published yet". Rendering the 2025 programme hour by hour underneath that
+ * gave the page a wall of specific times that a buyer skimming it could easily
+ * read as this year's, however it was labelled. Collapsed, "coming soon" is the
+ * page's answer and 2025 is there for anyone who deliberately asks for it.
+ */
+export function PastAgenda() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="agenda-2025"
+        className="inline-flex min-h-11 items-center gap-2 rounded-full border border-gray-200 bg-white px-6 text-sm font-semibold text-gray-900 transition-colors hover:border-brand-blue"
+      >
+        {open ? "Hide the 2025 schedule" : "See how 2025 ran, hour by hour"}
+        <ChevronDown
+          className={`h-4 w-4 transition-transform duration-200 ${
+            open ? "rotate-180" : ""
+          }`}
+          aria-hidden="true"
+        />
+      </button>
+
+      <div id="agenda-2025" hidden={!open} className="mt-10">
+        <Agenda />
+      </div>
+    </div>
+  );
+}

--- a/components/tickets/ticket-tiers.tsx
+++ b/components/tickets/ticket-tiers.tsx
@@ -5,7 +5,7 @@ import {
   type TicketTier,
 } from "@/lib/tickets";
 import { TicketCTA } from "./ticket-cta";
-import { Check, Crown, Presentation, Wrench, X } from "lucide-react";
+import { CalendarDays, Check, Crown, Presentation, Wrench, X } from "lucide-react";
 
 function TierCard({ tier }: { tier: TicketTier }) {
   return (
@@ -34,7 +34,6 @@ function TierCard({ tier }: { tier: TicketTier }) {
       )}
 
       <h3 className="text-lg font-bold text-white lg:text-2xl">{tier.name}</h3>
-      <p className="eyebrow mt-1 text-white/60">{tier.days}</p>
 
       <div className="mt-5 flex flex-wrap items-baseline gap-x-3 gap-y-1">
         <span className="text-3xl font-bold tabular-nums text-white">
@@ -55,6 +54,21 @@ function TierCard({ tier }: { tier: TicketTier }) {
       )}
 
       <ul className="mt-6 flex flex-col gap-3">
+        {/* Days lead, and in brighter type than the rest: which days a pass
+            covers is the first thing a buyer needs to settle, and it used to
+            sit above the price as an eyebrow where it read as a subtitle
+            rather than as part of what the ticket gets you. */}
+        {tier.days.map((day) => (
+          <li key={day} className="flex items-start gap-3">
+            <CalendarDays
+              className="mt-0.5 h-4 w-4 shrink-0 text-brand-gold"
+              aria-hidden="true"
+            />
+            <span className="text-sm font-semibold leading-relaxed text-white/90">
+              {day}
+            </span>
+          </li>
+        ))}
         {tier.includes.map((item) => (
           <li key={item} className="flex items-start gap-3">
             <Check

--- a/components/tickets/ticket-tiers.tsx
+++ b/components/tickets/ticket-tiers.tsx
@@ -59,13 +59,14 @@ function TierCard({ tier }: { tier: TicketTier }) {
             sit above the price as an eyebrow where it read as a subtitle
             rather than as part of what the ticket gets you. */}
         {tier.days.map((day) => (
-          <li key={day} className="flex items-start gap-3">
+          <li key={day.label} className="flex items-start gap-3">
             <CalendarDays
               className="mt-0.5 h-4 w-4 shrink-0 text-brand-gold"
               aria-hidden="true"
             />
-            <span className="text-sm font-semibold leading-relaxed text-white/90">
-              {day}
+            <span className="text-sm leading-relaxed">
+              <span className="font-semibold text-white/90">{day.label}</span>
+              <span className="block text-white/60">{day.date}</span>
             </span>
           </li>
         ))}
@@ -90,6 +91,12 @@ function TierCard({ tier }: { tier: TicketTier }) {
           </li>
         ))}
       </ul>
+
+      {tier.note && (
+        <p className="mt-5 rounded-md border border-white/20 bg-white/5 p-3 text-xs leading-relaxed text-white/60">
+          {tier.note}
+        </p>
+      )}
 
       <div className="mt-6 border-t border-white/20 pt-4">
         <p className="eyebrow text-white/60">Best for</p>

--- a/lib/faq-data.ts
+++ b/lib/faq-data.ts
@@ -90,6 +90,13 @@ export const faqData: FAQItem[] = [
     category: "Registration & Tickets",
   },
   {
+    id: 24,
+    question: "Can I come to the Mixer on October 24?",
+    answer:
+      "The Mixer is invitation only, so it is not sold as its own ticket. Speakers, invited guests, partners and KOLs are admitted automatically. The ALL ACCESS PASS is the way to buy in. The workshop on October 22 and the conference on October 23 are the two days open to everyone.",
+    category: "Registration & Tickets",
+  },
+  {
     id: 23,
     question: "Can I buy tickets for my team?",
     answer:

--- a/lib/tickets.ts
+++ b/lib/tickets.ts
@@ -70,15 +70,19 @@ export interface TicketTier {
   discountLabel?: string;
   /** Which days the pass covers, e.g. "Day 2 · Conference". */
   /**
-   * Which days the pass covers, one entry per day. These lead the card's list
-   * because "when am I coming?" is the first thing a buyer needs to settle.
+   * Which days the pass covers, one entry per day, each with its calendar date.
+   * These lead the card's list because "when am I coming?" is the first thing a
+   * buyer needs to settle — and without the date they cannot book travel from
+   * the card alone.
    */
-  days: string[];
+  days: { label: string; date: string }[];
   includes: string[];
   /** Stated plainly on the card. A day-limited pass must say what it is not. */
   excludes?: string[];
   /** Sells the most. Distinct from `featured`, which marks the pick of a group. */
   bestSeller?: boolean;
+  /** A rule about the pass that an includes bullet cannot carry on its own. */
+  note?: string;
   bestFor: string;
   /** Highlighted as the recommended pick within its group. */
   featured?: boolean;
@@ -104,7 +108,7 @@ export const ticketGroups: TicketGroup[] = [
     title: "VIP & All Access",
     icon: "crown",
     description:
-      "Priority entry, the speakers lounge, and the rooms where introductions happen.",
+      "Thursday 22 to Saturday 24 October, depending on the pass. Priority entry, the speakers lounge, and the rooms where introductions happen.",
   },
 ];
 
@@ -117,7 +121,7 @@ export const ticketTiers: TicketTier[] = [
     price: 7_500,
     standardPrice: 10_000,
     discountLabel: "25% OFF",
-    days: ["Day 2 · Conference Day"],
+    days: [{ label: "Day 2 · Conference Day", date: "Fri 23 Oct" }],
     includes: ["Access to the main stage and exhibition area"],
     bestFor:
       "Students, beginners, career switchers, and anyone exploring Web3, AI or tech for the first time.",
@@ -130,7 +134,7 @@ export const ticketTiers: TicketTier[] = [
     price: 15_000,
     standardPrice: 20_000,
     discountLabel: "25% OFF",
-    days: ["Day 2 · Conference Day"],
+    days: [{ label: "Day 2 · Conference Day", date: "Fri 23 Oct" }],
     includes: ["Access to the main stage and exhibition area", "Lunch"],
     bestFor:
       "Operators, engineers and marketers past the basics, who want the sessions that move their work forward and the lunch where conversations start.",
@@ -142,7 +146,7 @@ export const ticketTiers: TicketTier[] = [
     price: 26_250,
     standardPrice: 35_000,
     discountLabel: "25% OFF",
-    days: ["Day 2 · Conference Day"],
+    days: [{ label: "Day 2 · Conference Day", date: "Fri 23 Oct" }],
     includes: [
       "Access to the main stage and exhibition area",
       "Lunch",
@@ -158,7 +162,7 @@ export const ticketTiers: TicketTier[] = [
     group: "conference",
     price: 150_000,
     standardPrice: 175_000,
-    days: ["Day 2 · Conference Day"],
+    days: [{ label: "Day 2 · Conference Day", date: "Fri 23 Oct" }],
     includes: [
       "Five tickets, covering five people",
       "Access to the main stage and exhibition area",
@@ -177,7 +181,10 @@ export const ticketTiers: TicketTier[] = [
     price: 11_250,
     standardPrice: 15_000,
     discountLabel: "25% OFF",
-    days: ["Day 1 Morning · Workshop", "Day 2 · Conference Day"],
+    days: [
+      { label: "Day 1 Morning · Workshop", date: "Thu 22 Oct" },
+      { label: "Day 2 · Conference Day", date: "Fri 23 Oct" },
+    ],
     includes: [
       "Access to the workshop and breakfast on Day 1",
       "Access to the main stage and exhibition area",
@@ -192,7 +199,10 @@ export const ticketTiers: TicketTier[] = [
     price: 30_000,
     standardPrice: 40_000,
     discountLabel: "25% OFF",
-    days: ["Day 1 Morning · Workshop", "Day 2 · Conference Day"],
+    days: [
+      { label: "Day 1 Morning · Workshop", date: "Thu 22 Oct" },
+      { label: "Day 2 · Conference Day", date: "Fri 23 Oct" },
+    ],
     includes: [
       "Access to the workshop and breakfast on Day 1",
       "Access to the main stage and exhibition area",
@@ -210,7 +220,7 @@ export const ticketTiers: TicketTier[] = [
     price: 33_750,
     standardPrice: 45_000,
     discountLabel: "25% OFF",
-    days: ["Day 1 Evening · The Back Room"],
+    days: [{ label: "Day 1 Evening · The Back Room", date: "Thu 22 Oct" }],
     includes: [
       "Access to pitch for funding",
       "Direct access to investors and high-growth startups",
@@ -227,7 +237,7 @@ export const ticketTiers: TicketTier[] = [
     name: "PRIME PASS",
     group: "vip",
     price: 150_000,
-    days: ["Day 2 · Conference Day, VIP"],
+    days: [{ label: "Day 2 · Conference Day, VIP", date: "Fri 23 Oct" }],
     includes: [
       "Access to the main stage and exhibition area",
       "Event merch",
@@ -243,7 +253,10 @@ export const ticketTiers: TicketTier[] = [
     name: "EXEC PASS",
     group: "vip",
     price: 160_000,
-    days: ["Day 1 Morning · Workshop", "Day 2 · Conference Day, VIP"],
+    days: [
+      { label: "Day 1 Morning · Workshop", date: "Thu 22 Oct" },
+      { label: "Day 2 · Conference Day, VIP", date: "Fri 23 Oct" },
+    ],
     includes: [
       "Access to the workshop and breakfast on Day 1",
       "Access to the main stage and exhibition area on Day 2",
@@ -261,9 +274,9 @@ export const ticketTiers: TicketTier[] = [
     group: "vip",
     price: 185_000,
     days: [
-      "Day 1 · Workshop and The Back Room",
-      "Day 2 · Conference Day, VIP",
-      "Day 3 · Industry mixer",
+      { label: "Day 1 · Workshop and The Back Room", date: "Thu 22 Oct" },
+      { label: "Day 2 · Conference Day, VIP", date: "Fri 23 Oct" },
+      { label: "Day 3 · The Mixer", date: "Sat 24 Oct" },
     ],
     includes: [
       "Access to the workshop and breakfast on Day 1",
@@ -273,8 +286,9 @@ export const ticketTiers: TicketTier[] = [
       "Access to the VIP and speakers room",
       "Buffet lunch",
       "Priority check-in and private entry",
-      "Industry mixer",
+      "The Day 3 mixer",
     ],
+    note: "The Day 3 mixer is invitation only. It is not sold separately. This pass is the way to buy in; speakers, invited guests and partners are admitted automatically.",
     bestFor:
       "Founders, investors and senior operators who plan to be in Lagos for all three days.",
     featured: true,

--- a/lib/tickets.ts
+++ b/lib/tickets.ts
@@ -69,7 +69,11 @@ export interface TicketTier {
   /** Badge copy for the discount, e.g. "25% OFF". Omitted when there is none. */
   discountLabel?: string;
   /** Which days the pass covers, e.g. "Day 2 · Conference". */
-  days: string;
+  /**
+   * Which days the pass covers, one entry per day. These lead the card's list
+   * because "when am I coming?" is the first thing a buyer needs to settle.
+   */
+  days: string[];
   includes: string[];
   /** Stated plainly on the card. A day-limited pass must say what it is not. */
   excludes?: string[];
@@ -113,7 +117,7 @@ export const ticketTiers: TicketTier[] = [
     price: 7_500,
     standardPrice: 10_000,
     discountLabel: "25% OFF",
-    days: "Day 2 · Conference Day",
+    days: ["Day 2 · Conference Day"],
     includes: ["Access to the main stage and exhibition area"],
     bestFor:
       "Students, beginners, career switchers, and anyone exploring Web3, AI or tech for the first time.",
@@ -126,7 +130,7 @@ export const ticketTiers: TicketTier[] = [
     price: 15_000,
     standardPrice: 20_000,
     discountLabel: "25% OFF",
-    days: "Day 2 · Conference Day",
+    days: ["Day 2 · Conference Day"],
     includes: ["Access to the main stage and exhibition area", "Lunch"],
     bestFor:
       "Operators, engineers and marketers past the basics, who want the sessions that move their work forward and the lunch where conversations start.",
@@ -138,7 +142,7 @@ export const ticketTiers: TicketTier[] = [
     price: 26_250,
     standardPrice: 35_000,
     discountLabel: "25% OFF",
-    days: "Day 2 · Conference Day",
+    days: ["Day 2 · Conference Day"],
     includes: [
       "Access to the main stage and exhibition area",
       "Lunch",
@@ -154,12 +158,12 @@ export const ticketTiers: TicketTier[] = [
     group: "conference",
     price: 150_000,
     standardPrice: 175_000,
-    days: "Day 2 · Conference Day · 5 BECOME PASS tickets",
+    days: ["Day 2 · Conference Day"],
     includes: [
+      "Five tickets, covering five people",
       "Access to the main stage and exhibition area",
       "Lunch",
       "Event merch",
-      "5 × BECOME PASS tickets",
     ],
     bestFor:
       "Companies sending a delegation. One purchase covers five people.",
@@ -173,10 +177,10 @@ export const ticketTiers: TicketTier[] = [
     price: 11_250,
     standardPrice: 15_000,
     discountLabel: "25% OFF",
-    days: "Day 1 Morning · Workshop + Day 2 · Conference",
+    days: ["Day 1 Morning · Workshop", "Day 2 · Conference Day"],
     includes: [
-      "Everything in the BUIDL PASS",
       "Access to the workshop and breakfast on Day 1",
+      "Access to the main stage and exhibition area",
     ],
     bestFor:
       "Developers, designers, marketers, technical founders and community managers who learn best by doing.",
@@ -188,10 +192,12 @@ export const ticketTiers: TicketTier[] = [
     price: 30_000,
     standardPrice: 40_000,
     discountLabel: "25% OFF",
-    days: "Day 1 Morning · Workshop + Day 2 · Conference",
+    days: ["Day 1 Morning · Workshop", "Day 2 · Conference Day"],
     includes: [
-      "Everything in the BECOME PASS",
       "Access to the workshop and breakfast on Day 1",
+      "Access to the main stage and exhibition area",
+      "Lunch",
+      "Event merch",
     ],
     bestFor:
       "Builders and creators who want the hands-on workshop plus the full conference day, merch and lunch included.",
@@ -204,7 +210,7 @@ export const ticketTiers: TicketTier[] = [
     price: 33_750,
     standardPrice: 45_000,
     discountLabel: "25% OFF",
-    days: "Day 1 Evening · The Back Room only",
+    days: ["Day 1 Evening · The Back Room"],
     includes: [
       "Access to pitch for funding",
       "Direct access to investors and high-growth startups",
@@ -221,7 +227,7 @@ export const ticketTiers: TicketTier[] = [
     name: "PRIME PASS",
     group: "vip",
     price: 150_000,
-    days: "Day 2 VIP · Conference Day only",
+    days: ["Day 2 · Conference Day, VIP"],
     includes: [
       "Access to the main stage and exhibition area",
       "Event merch",
@@ -237,7 +243,7 @@ export const ticketTiers: TicketTier[] = [
     name: "EXEC PASS",
     group: "vip",
     price: 160_000,
-    days: "Day 1 Morning · Workshop + Day 2 VIP · Conference",
+    days: ["Day 1 Morning · Workshop", "Day 2 · Conference Day, VIP"],
     includes: [
       "Access to the workshop and breakfast on Day 1",
       "Access to the main stage and exhibition area on Day 2",
@@ -254,7 +260,11 @@ export const ticketTiers: TicketTier[] = [
     name: "ALL ACCESS PASS",
     group: "vip",
     price: 185_000,
-    days: "Day 1 Workshop & Back Room + Day 2 VIP Conference + Day 3 Mixer",
+    days: [
+      "Day 1 · Workshop and The Back Room",
+      "Day 2 · Conference Day, VIP",
+      "Day 3 · Industry mixer",
+    ],
     includes: [
       "Access to the workshop and breakfast on Day 1",
       "Access to the main conference and exhibition area on Day 2",


### PR DESCRIPTION
Both changes are about not making a buyer hold another ticket in their head to understand the one they are reading.

## No card references another card

Three cards pointed elsewhere instead of saying what you get:

| pass | was | now |
|---|---|---|
| BUIDL PLUS | "Everything in the BUIDL PASS" | Access to the workshop and breakfast on Day 1 · Access to the main stage and exhibition area |
| BECOME PLUS | "Everything in the BECOME PASS" | Access to the workshop and breakfast on Day 1 · Access to the main stage and exhibition area · Lunch · Event merch |
| CORPORATE CIRCLE | "5 × BECOME PASS tickets" | Five tickets, covering five people · Access to the main stage and exhibition area · Lunch · Event merch |

BUIDL PLUS was the worst of these — it sat in the Workshop group, so working out what it meant required scrolling back to a card in a *different* group. "Everything in …" now appears nowhere on the page.

## Days lead the list

The days were an eyebrow under the pass name and above the price, where they read as a subtitle rather than as part of what the ticket buys. They are also the first thing a buyer needs to settle, so they now open the list in brighter type with a calendar mark — **one line per day**, instead of one string with pluses in it:

```
was:  Day 1 Morning · Workshop + Day 2 · Conference

now:  📅 Day 1 Morning · Workshop
      📅 Day 2 · Conference Day
      ✓  Access to the workshop and breakfast on Day 1
      ✓  Access to the main stage and exhibition area
```

CORPORATE CIRCLE also had its ticket count buried in the day line ("Day 2 · Conference Day · 5 BECOME PASS tickets"). Five tickets is not a day, so it moved into the list.

## Implementation

`days` becomes `string[]`. Only the tier cards and `/llms.txt` read it; llms.txt joins the entries with `;` so AI clients get each day distinctly rather than a run-on.

## Verification

Production build: "Everything in" appears 0 times on `/tickets`, "5 × BECOME PASS" is gone, all 10 offers and the VideoObject still emit correctly in JSON-LD, routes 200, tsc and biome clean, 52/52 pages.