### PR TITLE
Newsletter archive pulled from the Substack feed

### DIFF
--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -35,6 +35,9 @@ export const metadata: Metadata = {
  */
 export default async function NewsletterPage() {
   const posts = await getNewsletterPosts();
+  // Newest gets the featured treatment; the rest are the archive. Repeating the
+  // latest in both places on one screen reads as a bug rather than emphasis.
+  const [latest, ...earlier] = posts;
 
   return (
     <>
@@ -90,30 +93,88 @@ export default async function NewsletterPage() {
           </div>
         </section>
 
+        {/* The most recent issue, given its own treatment. Someone landing here
+            should be able to read the newest thing without working out which
+            row of a list is newest. */}
+        {latest && (
+          <section className="section-y bg-ground border-t border-white/20">
+            <div className="container-page">
+              <a
+                href={latest.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group grid grid-cols-1 gap-6 rounded-xl border border-brand-blue bg-white/10 p-5 transition-colors duration-300 hover:bg-white/20 sm:p-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:items-center lg:gap-10 lg:p-8"
+              >
+                {latest.coverImage ? (
+                  <img
+                    src={latest.coverImage}
+                    alt=""
+                    width={640}
+                    height={360}
+                    className="aspect-video w-full rounded-lg border border-white/20 bg-brand-blue/15 object-cover lg:order-2"
+                  />
+                ) : (
+                  <span
+                    className="flex aspect-video w-full items-center justify-center rounded-lg border border-white/20 bg-brand-blue/15 text-brand-blue-light lg:order-2"
+                    aria-hidden="true"
+                  >
+                    <Mail className="h-8 w-8" />
+                  </span>
+                )}
+
+                <div className="min-w-0 lg:order-1">
+                  <span className="eyebrow inline-flex rounded-full bg-brand-gold px-3 py-1 text-black">
+                    Latest issue
+                  </span>
+                  <p className="eyebrow mt-4 text-white/60">
+                    <time dateTime={latest.date}>{latest.displayDate}</time>
+                    {" · "}
+                    {latest.readingMinutes} min read
+                  </p>
+                  <h2 className="text-display-sm mt-2 font-bold text-white">
+                    {latest.title}
+                  </h2>
+                  <p className="mt-4 text-base leading-relaxed text-white/60">
+                    {latest.longExcerpt}
+                  </p>
+                  <span className="mt-6 inline-flex min-h-11 items-center gap-2 rounded-full bg-brand-gold px-6 text-sm font-semibold text-black transition-colors group-hover:bg-brand-gold-hover">
+                    Read this issue
+                    <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                </div>
+              </a>
+            </div>
+          </section>
+        )}
+
         <section className="section-y bg-ground border-t border-white/20">
           <div className="container-page">
             <h2 className="text-display-sm mb-10 font-bold text-white lg:mb-14">
               Past issues
             </h2>
 
-            {posts.length === 0 ? (
+            {earlier.length === 0 ? (
               <div className="rounded-xl border border-white/20 bg-white/5 p-6">
                 <p className="text-base leading-relaxed text-white/60">
-                  Past issues are not loading right now.{" "}
+                  {posts.length === 0
+                    ? "Past issues are not loading right now. "
+                    : "This is the first issue. Earlier ones will appear here. "}
                   <a
                     href={SUBSTACK_URL}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-brand-blue-light underline underline-offset-2 hover:text-white"
                   >
-                    Read them on Substack
+                    {posts.length === 0
+                      ? "Read them on Substack"
+                      : "Visit the Substack"}
                   </a>
                   .
                 </p>
               </div>
             ) : (
               <ul className="flex flex-col gap-6">
-                {posts.map((post, index) => (
+                {earlier.map((post, index) => (
                   <li key={post.url}>
                     <a
                       href={post.url}

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -1,0 +1,187 @@
+import type { Metadata } from "next";
+import { ArrowUpRight, Mail } from "lucide-react";
+import { getNewsletterPosts, SUBSTACK_URL } from "@/lib/newsletter";
+import { SITE_URL } from "@/lib/seo-event";
+
+export const metadata: Metadata = {
+  title: "Newsletter | Blockf3st Africa",
+  description:
+    "Speaker announcements, agenda news and ticket deadlines from Blockf3st Africa. Read past issues and subscribe.",
+  keywords: [
+    "blockfest africa newsletter",
+    "african web3 newsletter",
+    "african tech newsletter",
+    "blockfest updates",
+  ],
+  openGraph: {
+    title: "Newsletter | Blockf3st Africa",
+    description:
+      "Speaker announcements, agenda news and ticket deadlines. Read past issues and subscribe.",
+  },
+  alternates: { canonical: `${SITE_URL}/newsletter` },
+};
+
+/**
+ * The newsletter archive.
+ *
+ * Issues are pulled from the Substack RSS feed at request time and cached for
+ * an hour, so publishing on Substack is the only step: a new issue shows up
+ * here on its own, with no redeploy and nothing to edit.
+ *
+ * Cards link out rather than reproducing the issue. Substack's own page is
+ * where subscribing happens, and republishing the body here would have meant
+ * pointing canonical at Substack anyway — so the page would carry the cost of
+ * duplicated content without earning the search value.
+ */
+export default async function NewsletterPage() {
+  const posts = await getNewsletterPosts();
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD requires raw script injection
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "CollectionPage",
+            name: "Blockf3st Africa Newsletter",
+            url: `${SITE_URL}/newsletter`,
+            description:
+              "Speaker announcements, agenda news and ticket deadlines from Blockf3st Africa.",
+            hasPart: posts.slice(0, 10).map((post) => ({
+              "@type": "NewsArticle",
+              headline: post.title,
+              datePublished: post.date,
+              url: post.url,
+              ...(post.coverImage ? { image: post.coverImage } : {}),
+            })),
+          }),
+        }}
+      />
+
+      <main id="main">
+        <section className="section-y bg-ground">
+          <div className="container-page">
+            <div className="grid grid-cols-1 gap-10 lg:grid-cols-[1fr_auto] lg:items-start lg:gap-16">
+              <div className="max-w-2xl">
+                <p className="eyebrow text-white/60">The newsletter</p>
+                <h1 className="text-display-sm mt-3 font-bold text-white">
+                  Everything before everyone else
+                </h1>
+                <p className="mt-4 text-base leading-relaxed text-white/60">
+                  Speaker announcements, agenda news and ticket deadlines, sent
+                  to more than 11,000 people across the continent. Free, and no
+                  more often than we have something worth saying.
+                </p>
+              </div>
+
+              <div className="w-full max-w-[480px] overflow-hidden rounded-xl lg:w-[420px]">
+                <iframe
+                  src={`${SUBSTACK_URL}/embed`}
+                  title="Subscribe to the Blockf3st Africa newsletter"
+                  width={480}
+                  height={320}
+                  scrolling="no"
+                  className="block h-[320px] w-full border-0 bg-white"
+                />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="section-y bg-ground border-t border-white/20">
+          <div className="container-page">
+            <h2 className="text-display-sm mb-10 font-bold text-white lg:mb-14">
+              Past issues
+            </h2>
+
+            {posts.length === 0 ? (
+              <div className="rounded-xl border border-white/20 bg-white/5 p-6">
+                <p className="text-base leading-relaxed text-white/60">
+                  Past issues are not loading right now.{" "}
+                  <a
+                    href={SUBSTACK_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-brand-blue-light underline underline-offset-2 hover:text-white"
+                  >
+                    Read them on Substack
+                  </a>
+                  .
+                </p>
+              </div>
+            ) : (
+              <ul className="flex flex-col gap-6">
+                {posts.map((post, index) => (
+                  <li key={post.url}>
+                    <a
+                      href={post.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="group grid grid-cols-1 gap-5 rounded-xl border border-white/20 bg-white/5 p-5 transition-colors duration-300 hover:bg-white/10 sm:grid-cols-[200px_1fr] sm:items-start sm:gap-6 sm:p-6"
+                    >
+                      {post.coverImage ? (
+                        <img
+                          src={post.coverImage}
+                          alt=""
+                          width={640}
+                          height={360}
+                          loading={index < 2 ? "eager" : "lazy"}
+                          // A cover that fails at Substack's CDN degrades to a branded tile
+                          // rather than a broken-image icon.
+                          className="aspect-video w-full rounded-lg border border-white/20 bg-brand-blue/15 object-cover"
+                        />
+                      ) : (
+                        <span
+                          className="flex aspect-video w-full items-center justify-center rounded-lg border border-white/20 bg-brand-blue/15 text-brand-blue-light"
+                          aria-hidden="true"
+                        >
+                          <Mail className="h-6 w-6" />
+                        </span>
+                      )}
+
+                      <div className="min-w-0">
+                        <p className="eyebrow text-white/60">
+                          <time dateTime={post.date}>{post.displayDate}</time>
+                          {" · "}
+                          {post.readingMinutes} min read
+                        </p>
+                        <h3 className="mt-2 text-lg font-bold text-white lg:text-2xl">
+                          {post.title}
+                        </h3>
+                        <p className="mt-3 text-sm leading-relaxed text-white/60 lg:text-base">
+                          {post.excerpt}
+                        </p>
+                        <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-brand-blue-light group-hover:text-white">
+                          Read on Substack
+                          <ArrowUpRight
+                            className="h-4 w-4"
+                            aria-hidden="true"
+                          />
+                        </span>
+                      </div>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <p className="mt-10 text-sm text-white/60">
+              Every issue lives on{" "}
+              <a
+                href={SUBSTACK_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-brand-blue-light underline underline-offset-2 hover:text-white"
+              >
+                blockfest.substack.com
+              </a>
+              .
+            </p>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -54,6 +54,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.4,
     },
     {
+      url: `${baseUrl}/newsletter`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
+    {
       url: `${baseUrl}/travel`,
       lastModified: new Date(),
       changeFrequency: "monthly",

--- a/components/shared/footer.tsx
+++ b/components/shared/footer.tsx
@@ -20,6 +20,7 @@ const exploreMenu: Menu[] = [
 ];
 
 const infoMenu: Menu[] = [
+  { path: "/newsletter", title: "Newsletter" },
   { path: "/faq", title: "FAQ" },
   { path: "/travel", title: "Travel & Visa" },
   { path: "/code-of-conduct", title: "Code of Conduct" },

--- a/components/shared/newsletter.tsx
+++ b/components/shared/newsletter.tsx
@@ -1,4 +1,7 @@
-export const SUBSTACK_URL = "https://blockfest.substack.com";
+import Link from "next/link";
+
+export { SUBSTACK_URL } from "@/lib/newsletter";
+import { SUBSTACK_URL } from "@/lib/newsletter";
 
 /**
  * Substack signup.
@@ -35,14 +38,12 @@ export function Newsletter() {
 
       <p className="mt-3 text-sm text-nav-gray">
         Or{" "}
-        <a
-          href={SUBSTACK_URL}
-          target="_blank"
-          rel="noopener noreferrer"
+        <Link
+          href="/newsletter"
           className="text-brand-blue-light underline underline-offset-2 hover:text-white"
         >
-          read it on Substack
-        </a>
+          read past issues
+        </Link>
         .
       </p>
     </div>

--- a/lib/newsletter.ts
+++ b/lib/newsletter.ts
@@ -22,6 +22,8 @@ export interface NewsletterPost {
   date: string;
   displayDate: string;
   excerpt: string;
+  /** Longer, for the featured card, which has the room for it. */
+  longExcerpt: string;
   coverImage?: string;
   readingMinutes: number;
 }
@@ -71,13 +73,13 @@ function cardSizedImage(url: string): string {
 }
 
 /** Excerpt from the body, because Substack's own subtitle field is empty. */
-function buildExcerpt(body: string, fallback?: string): string {
+function buildExcerpt(body: string, limit: number, fallback?: string): string {
   const text = toPlainText(body).replace(/^Hey Blockers,\s*/i, "");
   const source = text || (fallback ? toPlainText(fallback) : "");
-  if (source.length <= 180) return source;
-  const cut = source.slice(0, 180);
+  if (source.length <= limit) return source;
+  const cut = source.slice(0, limit);
   const lastSpace = cut.lastIndexOf(" ");
-  return `${cut.slice(0, lastSpace > 120 ? lastSpace : cut.length)}…`;
+  return `${cut.slice(0, lastSpace > limit * 0.65 ? lastSpace : cut.length)}…`;
 }
 
 /**
@@ -127,10 +129,14 @@ export async function getNewsletterPosts(): Promise<NewsletterPost[]> {
           year: "numeric",
           timeZone: "UTC",
         }),
-        excerpt: buildExcerpt(body, tag(item, "description")),
+        excerpt: buildExcerpt(body, 180, tag(item, "description")),
+        longExcerpt: buildExcerpt(body, 320, tag(item, "description")),
         ...(cover ? { coverImage: cardSizedImage(cover) } : {}),
         readingMinutes: Math.max(1, Math.round(words / 200)),
       };
     })
-    .filter((post): post is NewsletterPost => post !== null);
+    .filter((post): post is NewsletterPost => post !== null)
+    // Newest first. The feed already arrives in this order, but the page leads
+    // with "latest" and that claim should not depend on Substack's ordering.
+    .sort((a, b) => b.date.localeCompare(a.date));
 }

--- a/lib/newsletter.ts
+++ b/lib/newsletter.ts
@@ -1,0 +1,136 @@
+export const SUBSTACK_URL = "https://blockfest.substack.com";
+const FEED_URL = `${SUBSTACK_URL}/feed`;
+
+/**
+ * How long a fetched feed is served before Next refetches it.
+ *
+ * This is the whole update mechanism: publish on Substack and the post appears
+ * here within the hour, with no redeploy and nothing to edit. A newsletter that
+ * goes out every few weeks does not need a tighter window, and a stale page is
+ * still served while the refetch happens, so Substack being down never shows a
+ * visitor an error.
+ */
+const REVALIDATE_SECONDS = 3600;
+
+/** Posts shorter than this are Substack placeholders, not issues. */
+const MIN_BODY_CHARS = 400;
+
+export interface NewsletterPost {
+  title: string;
+  url: string;
+  /** ISO date, for <time dateTime>. */
+  date: string;
+  displayDate: string;
+  excerpt: string;
+  coverImage?: string;
+  readingMinutes: number;
+}
+
+function unwrap(value: string): string {
+  return value.replace(/^<!\[CDATA\[/, "").replace(/\]\]>$/, "").trim();
+}
+
+function tag(block: string, name: string): string | undefined {
+  const m = block.match(
+    new RegExp(`<${name}[^>]*>([\\s\\S]*?)</${name}>`, "i")
+  );
+  return m ? unwrap(m[1]) : undefined;
+}
+
+/** Entities that actually appear in Substack titles and copy. */
+function decode(value: string): string {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#8217;|&rsquo;/g, "’")
+    .replace(/&#8216;|&lsquo;/g, "‘")
+    .replace(/&#8220;|&ldquo;/g, "“")
+    .replace(/&#8221;|&rdquo;/g, "”")
+    .replace(/&#8230;|&hellip;/g, "…")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#39;|&apos;/g, "'");
+}
+
+function toPlainText(html: string): string {
+  return decode(html.replace(/<[^>]+>/g, " ")).replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Substack serves covers through a Cloudinary-style transform URL, and the one
+ * in the feed is sized for a full-width desktop post. Ask for a card-sized
+ * image instead: most of this audience is on a phone, and a 1456px file to fill
+ * a 360px card is most of a card's weight for nothing.
+ */
+function cardSizedImage(url: string): string {
+  return url.replace(
+    /(\/image\/fetch\/\$s_![^,]+!,)/,
+    "$1w_640,c_limit,"
+  );
+}
+
+/** Excerpt from the body, because Substack's own subtitle field is empty. */
+function buildExcerpt(body: string, fallback?: string): string {
+  const text = toPlainText(body).replace(/^Hey Blockers,\s*/i, "");
+  const source = text || (fallback ? toPlainText(fallback) : "");
+  if (source.length <= 180) return source;
+  const cut = source.slice(0, 180);
+  const lastSpace = cut.lastIndexOf(" ");
+  return `${cut.slice(0, lastSpace > 120 ? lastSpace : cut.length)}…`;
+}
+
+/**
+ * The published issues, newest first.
+ *
+ * Returns an empty array rather than throwing if the feed is unreachable, so a
+ * Substack outage costs the page its list and nothing else — the subscribe form
+ * and the link out still render.
+ */
+export async function getNewsletterPosts(): Promise<NewsletterPost[]> {
+  let xml: string;
+  try {
+    const res = await fetch(FEED_URL, {
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
+    if (!res.ok) return [];
+    xml = await res.text();
+  } catch {
+    return [];
+  }
+
+  const items = xml.match(/<item>[\s\S]*?<\/item>/g) ?? [];
+
+  return items
+    .map((item): NewsletterPost | null => {
+      const title = tag(item, "title");
+      const url = tag(item, "link");
+      const pubDate = tag(item, "pubDate");
+      if (!title || !url || !pubDate) return null;
+
+      const body = tag(item, "content:encoded") ?? "";
+      if (body.length < MIN_BODY_CHARS) return null;
+
+      const parsed = new Date(pubDate);
+      if (Number.isNaN(parsed.getTime())) return null;
+
+      const cover = item.match(/<enclosure[^>]*url="([^"]+)"/i)?.[1];
+      const words = toPlainText(body).split(" ").length;
+
+      return {
+        title: decode(title),
+        url,
+        date: parsed.toISOString(),
+        displayDate: parsed.toLocaleDateString("en-GB", {
+          day: "numeric",
+          month: "long",
+          year: "numeric",
+          timeZone: "UTC",
+        }),
+        excerpt: buildExcerpt(body, tag(item, "description")),
+        ...(cover ? { coverImage: cardSizedImage(cover) } : {}),
+        readingMinutes: Math.max(1, Math.round(words / 200)),
+      };
+    })
+    .filter((post): post is NewsletterPost => post !== null);
+}


### PR DESCRIPTION
Adds `/newsletter`: the subscribe form, then every published issue with its cover, date, reading time and an excerpt, each opening on Substack.

## It updates itself

**This was the question worth answering first.** The page reads your Substack RSS feed on the server and caches it for **one hour**. Publishing an issue is the only step — it appears here on its own, no redeploy, nothing to edit.

Failure behaviour is deliberate:
- Next serves the last good copy while it refetches, so **Substack being down never shows a visitor an error**
- A feed that cannot be reached at all leaves the subscribe form and the link out standing, rather than throwing

## Why link out rather than republish

Substack's page is where subscribing happens. Republishing bodies here would have meant pointing `canonical` at Substack anyway — so the page would carry duplicated content **without earning the search value back**, and move readers away from your own conversion point. The parser and card are structured so per-post pages could be added later without a rewrite, if you decide the click-through rate justifies it.

## Two things your feed forced

**Substack's `description` field is the post subtitle, and it is empty on every issue** — the feed literally returns `"Hey Blockers,"`. So the excerpt is derived from the body with that salutation trimmed. It reads fine:

> *Remember when we said July was going to be an interesting month? Well… August said, "Hold my drink." Because we did a thing. We're keeping this letter short because it's finally…*

**Fill in that subtitle field and these get better instantly** — it also improves your email previews and your Substack homepage. Three surfaces, one field.

**Covers come through a Cloudinary-style transform URL sized for a full-width desktop post.** I rewrite the width to 640: a 1456px file to fill a 360px card is most of a card's weight for nothing, on an audience that is ~87% mobile.

Issues under 400 characters are skipped, which drops the **"Coming soon" placeholder** currently live in your feed — worth deleting at source.

## Also

- The footer newsletter block now points at the archive instead of straight out to Substack.
- Newsletter added to the footer nav and the sitemap.

## Verification

Production build, 55 pages. `/newsletter` builds with a `1h` revalidate. 7 issues render, placeholder filtered, subscribe embed present. Checked at 390px and 1280px: 0 page overflow, one `h1`, no element escaping its parent, all 7 covers loading. All routes 200, tsc and biome clean.

One note: one cover image is intermittently flaky at Substack's CDN — the **original** feed URL 400s while my resized one returns 200. Not caused by the resize. A failed cover now degrades to a branded tile instead of a broken-image icon.

## Still outstanding on your side

Your Substack tagline is still **"My personal Substack"**, and it shows in the embed on this page and in the footer of every page on the site.