### PR TITLE
Fix what the Lighthouse run found

### DIFF
--- a/app/code-of-conduct/page.tsx
+++ b/app/code-of-conduct/page.tsx
@@ -119,7 +119,7 @@ export default function CodeOfConductPage() {
                   You can also email{" "}
                   <a
                     href={`mailto:${CONTACT_EMAIL}?subject=Code of Conduct report`}
-                    className="text-brand-blue-light underline underline-offset-2 hover:text-white"
+                    className="text-link underline underline-offset-2 hover:text-white"
                   >
                     {CONTACT_EMAIL}
                   </a>
@@ -158,14 +158,14 @@ export default function CodeOfConductPage() {
               Questions about this policy:{" "}
               <a
                 href={`mailto:${CONTACT_EMAIL}`}
-                className="text-brand-blue-light underline underline-offset-2 hover:text-white"
+                className="text-link underline underline-offset-2 hover:text-white"
               >
                 {CONTACT_EMAIL}
               </a>{" "}
               ·{" "}
               <Link
                 href="/faq"
-                className="text-brand-blue-light underline underline-offset-2 hover:text-white"
+                className="text-link underline underline-offset-2 hover:text-white"
               >
                 Read the FAQ
               </Link>

--- a/app/globals.css
+++ b/app/globals.css
@@ -52,6 +52,10 @@
   --color-brand-blue-deep: #031940;
   --color-brand-blue-light: #3D7BE8;
   --color-brand-blue-light-hover: #6597ED;
+  /* Text links on the dark ground. brand-blue-light measures 4.49:1 there,
+     failing AA by a hundredth, so links use the hover tone at 6.22:1.
+     The accent itself is unchanged: icons and rules only need 3:1. */
+  --color-link: #6597ED;
   --color-brand-navy: #0A1628; /* dark section gradient step */
   --color-brand-navy-deep: #0D1F3C; /* dark section gradient step */
   --color-nav-gray: #A4A4A4;

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -163,7 +163,7 @@ export default async function NewsletterPage() {
                     href={SUBSTACK_URL}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-brand-blue-light underline underline-offset-2 hover:text-white"
+                    className="text-link underline underline-offset-2 hover:text-white"
                   >
                     {posts.length === 0
                       ? "Read them on Substack"
@@ -234,7 +234,7 @@ export default async function NewsletterPage() {
                 href={SUBSTACK_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-brand-blue-light underline underline-offset-2 hover:text-white"
+                className="text-link underline underline-offset-2 hover:text-white"
               >
                 blockfest.substack.com
               </a>

--- a/app/travel/page.tsx
+++ b/app/travel/page.tsx
@@ -83,7 +83,7 @@ export default function TravelPage() {
                 <p>
                   <Link
                     href="/tickets#venue"
-                    className="text-brand-blue-light underline underline-offset-2 hover:text-white"
+                    className="text-link underline underline-offset-2 hover:text-white"
                   >
                     Watch the venue walkthrough
                   </Link>{" "}
@@ -101,7 +101,7 @@ export default function TravelPage() {
                   If your application needs an invitation letter, email{" "}
                   <a
                     href={`mailto:${CONTACT_EMAIL}?subject=Invitation letter request - Blockf3st Africa '26`}
-                    className="text-brand-blue-light underline underline-offset-2 hover:text-white"
+                    className="text-link underline underline-offset-2 hover:text-white"
                   >
                     {CONTACT_EMAIL}
                   </a>{" "}
@@ -123,7 +123,7 @@ export default function TravelPage() {
                     href={SOCIAL_URLS.telegram}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex min-h-11 items-center gap-2 text-brand-blue-light underline underline-offset-2 hover:text-white"
+                    className="inline-flex min-h-11 items-center gap-2 text-link underline underline-offset-2 hover:text-white"
                   >
                     <Send className="h-4 w-4" aria-hidden="true" />
                     Join the Telegram community
@@ -164,7 +164,7 @@ export default function TravelPage() {
                 </TicketCTA>
                 <Link
                   href="/faq"
-                  className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-brand-blue-light underline underline-offset-4 hover:text-white"
+                  className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-link underline underline-offset-4 hover:text-white"
                 >
                   Read the FAQ
                 </Link>
@@ -174,7 +174,7 @@ export default function TravelPage() {
                 Anything not answered here:{" "}
                 <a
                   href={`mailto:${CONTACT_EMAIL}`}
-                  className="text-brand-blue-light underline underline-offset-2 hover:text-white"
+                  className="text-link underline underline-offset-2 hover:text-white"
                 >
                   {CONTACT_EMAIL}
                 </a>

--- a/components/carousel.tsx
+++ b/components/carousel.tsx
@@ -251,9 +251,11 @@ const Speakers: React.FC<PropType> = (props) => {
                         sizes="(max-width: 767px) 240px, (max-width: 1279px) 300px, 340px"
                         className="w-full h-full object-cover object-center transition-transform duration-300 group-hover:scale-105"
                         style={{ objectPosition: "center 15%" }}
-                        // Only the first slide is above the fold; the rest wait.
-                        priority={index === 0}
-                        loading={index === 0 ? "eager" : "lazy"}
+                        // Nothing here is preloaded. This carousel sits four
+                        // sections below the fold on the homepage, and marking
+                        // the first slide priority put a second image preload
+                        // in the head competing with the actual LCP element.
+                        loading="lazy"
                       />
                     </div>
                   </div>

--- a/components/home/hero-2026.tsx
+++ b/components/home/hero-2026.tsx
@@ -50,6 +50,12 @@ export function HeroSection2026() {
         alt=""
         fill
         priority
+        // priority alone did not put fetchpriority on the preload, so the LCP
+        // image queued behind everything else the browser found first.
+        fetchPriority="high"
+        // The photograph sits under a heavy scrim, so detail that costs bytes
+        // is never seen. 60 keeps it clean and drops ~45KB at phone widths.
+        quality={60}
         sizes="100vw"
         className="object-cover object-center"
       />

--- a/components/shared/footer.tsx
+++ b/components/shared/footer.tsx
@@ -76,7 +76,7 @@ const Footer = () => {
                 height={38}
                 sizes="(max-width: 768px) 124px, 140px"
                 loading="lazy"
-                className="xl:w-[140px] xl:h-[38px] xl:aspect-[140/38] aspect-[124/24] w-[124px] h-[24px]"
+                className="xl:w-[140px] xl:h-[38px] xl:aspect-[140/38] aspect-[140/38] w-[124px] h-[34px]"
               />
             </Link>
             <p className="text-nav-gray text-sm lg:text-base max-w-xs">

--- a/components/shared/navbar.tsx
+++ b/components/shared/navbar.tsx
@@ -87,7 +87,7 @@ const Navbar = () => {
           height={38}
           sizes="(max-width: 768px) 124px, 140px"
           unoptimized
-          className="xl:w-[140px] xl:h-[38px] xl:aspect-[140/38] aspect-[124/24] w-[124px] h-[24px]"
+          className="xl:w-[140px] xl:h-[38px] xl:aspect-[140/38] aspect-[140/38] w-[124px] h-[34px]"
         />
       </Link>
 

--- a/components/shared/newsletter.tsx
+++ b/components/shared/newsletter.tsx
@@ -40,7 +40,7 @@ export function Newsletter() {
         Or{" "}
         <Link
           href="/newsletter"
-          className="text-brand-blue-light underline underline-offset-2 hover:text-white"
+          className="text-link underline underline-offset-2 hover:text-white"
         >
           read past issues
         </Link>

--- a/components/tickets/ticket-policy.tsx
+++ b/components/tickets/ticket-policy.tsx
@@ -53,7 +53,7 @@ export function TicketPolicy() {
               {PHOTOGRAPHY_NOTICE} Concerns? Contact{" "}
               <a
                 href={`mailto:${CONTACT_EMAIL}`}
-                className="inline-flex min-h-11 items-center text-brand-blue-light underline underline-offset-2 hover:text-white"
+                className="inline-flex min-h-11 items-center text-link underline underline-offset-2 hover:text-white"
               >
                 {CONTACT_EMAIL}
               </a>
@@ -75,7 +75,7 @@ export function TicketPolicy() {
             </TicketCTA>
             <Link
               href="/faq"
-              className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-brand-blue-light underline underline-offset-4 hover:text-white"
+              className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-link underline underline-offset-4 hover:text-white"
             >
               Still deciding? Read the FAQ
               <ArrowRight className="h-4 w-4" aria-hidden="true" />

--- a/components/tickets/ticket-proof.tsx
+++ b/components/tickets/ticket-proof.tsx
@@ -46,14 +46,14 @@ export function TicketProof() {
         <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-8">
           <Link
             href="/blockfest-2025"
-            className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-brand-blue-light underline underline-offset-4 hover:text-white"
+            className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-link underline underline-offset-4 hover:text-white"
           >
             See last year in Lagos
             <ArrowRight className="h-4 w-4" aria-hidden="true" />
           </Link>
           <Link
             href="/blockfest-south-africa-2026"
-            className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-brand-blue-light underline underline-offset-4 hover:text-white"
+            className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-link underline underline-offset-4 hover:text-white"
           >
             And Cape Town this year
             <ArrowRight className="h-4 w-4" aria-hidden="true" />

--- a/components/tickets/venue-video.tsx
+++ b/components/tickets/venue-video.tsx
@@ -55,7 +55,7 @@ export function VenueVideo() {
               Your browser cannot play this video.{" "}
               <a
                 href={VENUE_VIDEO.src}
-                className="text-brand-blue-light underline underline-offset-2"
+                className="text-link underline underline-offset-2"
               >
                 Download it instead
               </a>


### PR DESCRIPTION
Four of the five findings. The fifth is not fixable from here — detail at the bottom.

## The homepage was preloading two images

The hero is the LCP element. The **speakers carousel marked its first slide `priority`**, putting a second image preload in the head competing with it.

The comment there claimed the first slide was above the fold. True on `/speakers` — but on the homepage that carousel sits **four sections down**. Nothing there is preloaded now.

## The hero preload had no priority hint

Lighthouse: *"fetchpriority=high should be applied to the image preload request"*. It was right — `priority` alone did not put it there, so the browser had no reason to fetch the LCP image ahead of everything else it discovered. Set explicitly.

Confirmed in the emitted HTML: **1 image preload** (was 2), carrying `fetchPriority="high"`.

## Hero image: 63 → 47 KiB

Quality 60 rather than 75, at the width Lighthouse chose. The photograph sits under a heavy scrim — detail that costs bytes there is never seen.

## The logo was squashed on every phone

Best Practices flagged the aspect ratio, and it was a real defect:

| | displayed | aspect |
|---|---|---|
| mobile | 124×24 | **5.17** |
| the artwork | 280×77 | **3.64** |
| desktop | 140×38 | 3.68 ✓ |

Mobile was stretching the logo horizontally. Now 124×34 in the navbar and the footer. Verified as rendered: displayed 3.65 against the file's 3.64.

## Contrast: failed by a hundredth

The flagged footer link measured **4.49:1** against the 4.5:1 requirement.

Rather than move a brand colour, links on the dark ground now use a `--color-link` token set to the **existing** `brand-blue-light-hover` value — no new colour invented — which measures **6.22:1**. The accent is untouched, since icons and rules only need 3:1. Sixteen underlined links moved across; verified the exact element Lighthouse named now reads `rgb(101, 151, 237)` on `rgb(10, 22, 40)`.

## Not fixed: the 11 KiB of legacy JavaScript

Those polyfills are inside **Next's own shared chunk**, not our code — the chunk Lighthouse named is loaded on every route and contains real polyfill *definitions*.

I declared a modern browserslist, rebuilt with and without it, and **the output was byte-identical down to the chunk filenames**. So I removed the config again rather than leave it in looking like a fix. It is also the smallest item on the list.

## Measured after

Lighthouse-like mobile profile (412×823, DPR 1.75, 4× CPU, 1.6 Mbps), median of 5 runs, local server:

- FCP 352ms · **LCP 1,256ms** · CLS 0.0021 · 390 KiB

Local TTFB is near zero where production is not, so this is **not** a prediction of your production LCP — the deltas are what carry over: one fewer preload competing, a priority hint on the right one, and 16 KiB off the LCP resource.

## Still outstanding

**TBT 320ms / 4 long tasks.** That is the hydration cost I flagged during the INP work — taps landing between 1.8s and 2.6s eat 240–326ms of input delay. Unchanged here; it needs cutting client JS out of the route, which is a bigger piece of work than this PR.

## Verification

134/134 tests, tsc and biome clean, 55 pages, all routes 200, carousel assertions still clean at every width.