### PR TITLE
Add /volunteer

### DIFF
--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -10,6 +10,7 @@ import {
   TICKET_PLATFORM_URL,
 } from "@/lib/tickets";
 import { SITE_URL } from "@/lib/seo-event";
+import { volunteerTeams } from "@/lib/volunteer";
 
 /**
  * /llms.txt — a plain-text brief for AI clients and agents.
@@ -74,6 +75,9 @@ export function GET() {
   only and is not sold separately: speakers, invited guests, partners and KOLs
   are admitted automatically, and the ALL ACCESS PASS also includes it.
 - Official ticket platform: ${TICKET_PLATFORM_URL}
+- Volunteering: applications are open across ${volunteerTeams.length} departments for
+  22 and 23 October. Roles, what each team does and the application form are at
+  ${SITE_URL}/volunteer
 
 ## Tickets
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -60,6 +60,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     },
     {
+      url: `${baseUrl}/volunteer`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/travel`,
       lastModified: new Date(),
       changeFrequency: "monthly",

--- a/app/volunteer/page.tsx
+++ b/app/volunteer/page.tsx
@@ -1,0 +1,385 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowUpRight,
+  CalendarDays,
+  ChevronDown,
+  ClipboardList,
+  FileText,
+  MapPin,
+  MessageCircle,
+} from "lucide-react";
+import {
+  volunteerDays,
+  volunteerExpectations,
+  volunteerTeams,
+  VOLUNTEER_CONTACT_EMAILS,
+  VOLUNTEER_FORM_URL,
+  VOLUNTEER_ROLES_DOC_URL,
+} from "@/lib/volunteer";
+import { CURRENT_EDITION, EVENT_ID, SITE_URL } from "@/lib/seo-event";
+
+const EVENT = CURRENT_EDITION;
+
+export const metadata: Metadata = {
+  title: "Volunteer | Blockf3st Africa '26 Lagos",
+  description: `Join the team behind ${EVENT.name}. Eight departments across logistics, hospitality, registration, stage and technical operations, editorial, media, design and partnerships. Applications are open.`,
+  keywords: [
+    "blockfest africa volunteer",
+    "volunteer tech conference lagos",
+    "event volunteer nigeria 2026",
+    "blockfest volunteer application",
+  ],
+  openGraph: {
+    title: "Volunteer | Blockf3st Africa '26 Lagos",
+    description:
+      "Be part of the team that builds Blockf3st. Eight departments, two days, applications open.",
+  },
+  alternates: { canonical: `${SITE_URL}/volunteer` },
+};
+
+/**
+ * The volunteer call.
+ *
+ * The roles document runs to eight departments and well over a hundred
+ * responsibilities. Flat on a page that is a wall nobody finishes, and the form
+ * asks people to read it before applying — so each department collapses to its
+ * purpose and who it suits, and opens to the full list. Native <details>, so it
+ * works with JavaScript off and a browser's find-in-page still reaches inside.
+ */
+export default function VolunteerPage() {
+  const creativeTeams = volunteerTeams.filter((t) => t.assessment === "creative");
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD requires raw script injection
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "WebPage",
+            name: "Volunteer",
+            url: `${SITE_URL}/volunteer`,
+            about: { "@id": EVENT_ID },
+            description: `Volunteer applications for ${EVENT.name}, across eight departments on 22 and 23 October 2026.`,
+          }),
+        }}
+      />
+
+      <main id="main">
+        {/* ---------- The ask ---------- */}
+        <section className="section-y bg-ground">
+          <div className="container-page">
+            <p className="eyebrow text-white/60">Join the team</p>
+            <h1 className="text-display-sm mt-3 max-w-3xl font-bold text-white">
+              Volunteer at Blockf3st Africa
+            </h1>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+              Volunteers are not event helpers here. They are part of the team
+              that builds Blockf3st, before, during and after. Depending on your
+              department you might be writing, filming, designing, running a
+              stage, moving equipment or looking after the people who came a
+              long way to be in the room.
+            </p>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+              We are looking for reliable, proactive people. Placement is based
+              on your skills, experience and availability, and on what the event
+              actually needs.
+            </p>
+
+            <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-6">
+              <a
+                href={VOLUNTEER_FORM_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex min-h-12 items-center gap-2 rounded-full bg-brand-gold px-8 text-base font-semibold text-black transition-colors duration-300 hover:bg-brand-gold-hover"
+              >
+                Apply to volunteer
+                <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+              </a>
+              <p className="text-sm text-white/60">
+                Read the roles below first. The form asks which department you
+                want.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* ---------- When ---------- */}
+        <section className="section-y bg-ground border-t border-white/20">
+          <div className="container-page">
+            <h2 className="text-display-sm font-bold text-white">
+              Two days on the floor
+            </h2>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+              {EVENT.location.venue}. Expect long days, a lot of standing and
+              walking, and problems to solve as they arrive.
+            </p>
+
+            <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-2">
+              {volunteerDays.map((day) => (
+                <div
+                  key={day.date}
+                  className="rounded-xl border border-white/20 bg-white/5 p-6"
+                >
+                  <span className="mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-brand-blue/15 text-brand-blue-light">
+                    <CalendarDays className="h-5 w-5" aria-hidden="true" />
+                  </span>
+                  <p className="eyebrow text-brand-gold">
+                    {day.weekday} {day.date}
+                  </p>
+                  <h3 className="mt-2 text-lg font-bold text-white lg:text-2xl">
+                    {day.title}
+                  </h3>
+                  <p className="mt-3 text-sm leading-relaxed text-white/60 lg:text-base">
+                    {day.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <p className="mt-6 flex items-start gap-2 text-sm text-white/60">
+              <MapPin className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+              Travelling in?{" "}
+              <Link
+                href="/travel"
+                className="text-link underline underline-offset-2 hover:text-white"
+              >
+                Getting to Lagos
+              </Link>{" "}
+              covers the venue, accommodation and moving around the city.
+            </p>
+          </div>
+        </section>
+
+        {/* ---------- Departments ---------- */}
+        <section className="section-y bg-ground border-t border-white/20">
+          <div className="container-page">
+            <h2 className="text-display-sm font-bold text-white">
+              {volunteerTeams.length} departments
+            </h2>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+              Open the one you are drawn to and read what it actually involves
+              before you apply. You pick a department on the form, and the
+              honest answer to &ldquo;which one?&rdquo; is usually in this list.
+            </p>
+
+            <div className="mt-8 flex flex-col gap-4">
+              {volunteerTeams.map((team) => (
+                <details
+                  key={team.id}
+                  id={team.id}
+                  className="group rounded-xl border border-white/20 bg-white/5 transition-colors duration-300 open:bg-white/10 hover:bg-white/10"
+                >
+                  <summary className="flex cursor-pointer list-none items-start justify-between gap-4 p-5 sm:p-6 [&::-webkit-details-marker]:hidden">
+                    <span className="min-w-0">
+                      <span className="block text-lg font-bold text-white lg:text-2xl">
+                        {team.name}
+                      </span>
+                      <span className="mt-2 block text-sm leading-relaxed text-white/60 lg:text-base">
+                        {team.purpose}
+                      </span>
+                      {!team.selectableInForm && (
+                        <span className="eyebrow mt-3 inline-flex rounded-full border border-white/20 px-3 py-1 text-white/60">
+                          Not yet on the form
+                        </span>
+                      )}
+                    </span>
+                    <ChevronDown
+                      className="mt-1 h-5 w-5 shrink-0 text-brand-gold transition-transform duration-200 group-open:rotate-180"
+                      aria-hidden="true"
+                    />
+                  </summary>
+
+                  <div className="border-t border-white/20 p-5 sm:p-6">
+                    <p className="eyebrow text-white/60">What you would do</p>
+                    <ul className="mt-4 flex flex-col gap-2.5">
+                      {team.responsibilities.map((item) => (
+                        <li key={item} className="flex items-start gap-3">
+                          <span
+                            className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-blue-light"
+                            aria-hidden="true"
+                          />
+                          <span className="text-sm leading-relaxed text-white/60 lg:text-base">
+                            {item}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+
+                    <div className="mt-6 border-t border-white/20 pt-4">
+                      <p className="eyebrow text-white/60">Ideal for</p>
+                      <p className="mt-2 text-sm leading-relaxed text-white/60 lg:text-base">
+                        {team.idealFor}
+                      </p>
+                    </div>
+
+                    {!team.selectableInForm && (
+                      <p className="mt-4 rounded-md border border-white/20 bg-white/5 p-3 text-xs leading-relaxed text-white/60">
+                        This department is not currently one of the options in
+                        the application form. Apply under Logistics and
+                        operations and say Registration in your answers, or
+                        email{" "}
+                        <a
+                          href={`mailto:${VOLUNTEER_CONTACT_EMAILS[1]}?subject=Volunteering - Registration team`}
+                          className="text-link underline underline-offset-2 hover:text-white"
+                        >
+                          {VOLUNTEER_CONTACT_EMAILS[1]}
+                        </a>
+                        .
+                      </p>
+                    )}
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ---------- What the form will ask ---------- */}
+        <section className="section-y bg-ground border-t border-white/20">
+          <div className="container-page">
+            <h2 className="text-display-sm font-bold text-white">
+              Before you open the form
+            </h2>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+              It is short, but two answers are worth preparing rather than
+              improvising.
+            </p>
+
+            <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-2">
+              <div className="rounded-xl border border-white/20 bg-white/5 p-6">
+                <span className="mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-brand-blue/15 text-brand-blue-light">
+                  <ClipboardList className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <h3 className="text-lg font-bold text-white lg:text-2xl">
+                  If you are applying to a creative team
+                </h3>
+                <p className="mt-3 text-sm leading-relaxed text-white/60 lg:text-base">
+                  {creativeTeams.map((t) => t.name).join(", ")}. You will be
+                  asked what kind of creative you are, for{" "}
+                  <span className="font-semibold text-white">
+                    three links to previous work
+                  </span>{" "}
+                  and whether you can work to real-time deadlines. Have the
+                  links ready.
+                </p>
+              </div>
+
+              <div className="rounded-xl border border-white/20 bg-white/5 p-6">
+                <span className="mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-brand-blue/15 text-brand-blue-light">
+                  <ClipboardList className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <h3 className="text-lg font-bold text-white lg:text-2xl">
+                  If you are applying to an operations team
+                </h3>
+                <p className="mt-3 text-sm leading-relaxed text-white/60 lg:text-base">
+                  You will be asked about any experience with crowd management,
+                  customer service, AV equipment or venue operations, and to
+                  describe{" "}
+                  <span className="font-semibold text-white">
+                    a time you solved a problem under pressure
+                  </span>
+                  . A real example beats a general one.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-6 rounded-xl border border-white/20 bg-white/5 p-6">
+              <span className="mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-brand-blue/15 text-brand-blue-light">
+                <MessageCircle className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <h3 className="text-lg font-bold text-white lg:text-2xl">
+                Give a phone number that works on WhatsApp
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-white/60 lg:text-base">
+                Everything after selection happens on WhatsApp. If the number on
+                your form is not reachable there, you will miss it.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* ---------- Expectations ---------- */}
+        <section className="section-y bg-ground border-t border-white/20">
+          <div className="container-page">
+            <h2 className="text-display-sm font-bold text-white">
+              What we ask of every volunteer
+            </h2>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+              Whichever department you land in. The form asks you to confirm you
+              understand this before you submit.
+            </p>
+
+            <ul className="mt-8 grid grid-cols-1 gap-3 md:grid-cols-2">
+              {volunteerExpectations.map((item) => (
+                <li
+                  key={item}
+                  className="flex items-start gap-3 rounded-xl border border-white/20 bg-white/5 p-4"
+                >
+                  <span
+                    className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-gold"
+                    aria-hidden="true"
+                  />
+                  <span className="text-sm leading-relaxed text-white/60 lg:text-base">
+                    {item}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        {/* ---------- Apply ---------- */}
+        <section className="section-y bg-ground border-t border-white/20">
+          <div className="container-page">
+            <div className="max-w-2xl">
+              <h2 className="text-display-sm font-bold text-white">
+                Apply
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-white/60">
+                Shortlisted volunteers are contacted for the next stage of
+                selection. The email will come from one of these addresses, so
+                check your spam folder for them:
+              </p>
+              <ul className="mt-4 flex flex-col gap-1.5">
+                {VOLUNTEER_CONTACT_EMAILS.map((email) => (
+                  <li key={email} className="text-sm text-white/90">
+                    <a
+                      href={`mailto:${email}`}
+                      className="text-link underline underline-offset-2 hover:text-white"
+                    >
+                      {email}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+
+              <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-6">
+                <a
+                  href={VOLUNTEER_FORM_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex min-h-12 items-center gap-2 rounded-full bg-brand-gold px-8 text-base font-semibold text-black transition-colors duration-300 hover:bg-brand-gold-hover"
+                >
+                  Open the application form
+                  <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                </a>
+                <a
+                  href={VOLUNTEER_ROLES_DOC_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-link underline underline-offset-4 hover:text-white"
+                >
+                  <FileText className="h-4 w-4" aria-hidden="true" />
+                  Read the full roles document
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/app/volunteer/page.tsx
+++ b/app/volunteer/page.tsx
@@ -13,7 +13,6 @@ import {
   volunteerDays,
   volunteerExpectations,
   volunteerTeams,
-  VOLUNTEER_CONTACT_EMAILS,
   VOLUNTEER_FORM_URL,
   VOLUNTEER_ROLES_DOC_URL,
 } from "@/lib/volunteer";
@@ -88,20 +87,18 @@ export default function VolunteerPage() {
               actually needs.
             </p>
 
-            <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-6">
+            {/* No apply link up here on purpose. The form asks people to read
+                the roles before filling it in, so the only link to it sits at
+                the foot of the page — a reader reaches it having passed the
+                departments rather than instead of them. */}
+            <div className="mt-8">
               <a
-                href={VOLUNTEER_FORM_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex min-h-12 items-center gap-2 rounded-full bg-brand-gold px-8 text-base font-semibold text-black transition-colors duration-300 hover:bg-brand-gold-hover"
+                href="#departments"
+                className="inline-flex min-h-12 items-center gap-2 rounded-full border border-white/20 px-7 text-base font-semibold text-white transition-colors duration-300 hover:bg-white/10"
               >
-                Apply to volunteer
-                <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                See the {volunteerTeams.length} departments
+                <ChevronDown className="h-4 w-4" aria-hidden="true" />
               </a>
-              <p className="text-sm text-white/60">
-                Read the roles below first. The form asks which department you
-                want.
-              </p>
             </div>
           </div>
         </section>
@@ -154,7 +151,10 @@ export default function VolunteerPage() {
         </section>
 
         {/* ---------- Departments ---------- */}
-        <section className="section-y bg-ground border-t border-white/20">
+        <section
+          id="departments"
+          className="section-y bg-ground border-t border-white/20"
+        >
           <div className="container-page">
             <h2 className="text-display-sm font-bold text-white">
               {volunteerTeams.length} departments
@@ -180,11 +180,6 @@ export default function VolunteerPage() {
                       <span className="mt-2 block text-sm leading-relaxed text-white/60 lg:text-base">
                         {team.purpose}
                       </span>
-                      {!team.selectableInForm && (
-                        <span className="eyebrow mt-3 inline-flex rounded-full border border-white/20 px-3 py-1 text-white/60">
-                          Not yet on the form
-                        </span>
-                      )}
                     </span>
                     <ChevronDown
                       className="mt-1 h-5 w-5 shrink-0 text-brand-gold transition-transform duration-200 group-open:rotate-180"
@@ -215,21 +210,6 @@ export default function VolunteerPage() {
                       </p>
                     </div>
 
-                    {!team.selectableInForm && (
-                      <p className="mt-4 rounded-md border border-white/20 bg-white/5 p-3 text-xs leading-relaxed text-white/60">
-                        This department is not currently one of the options in
-                        the application form. Apply under Logistics and
-                        operations and say Registration in your answers, or
-                        email{" "}
-                        <a
-                          href={`mailto:${VOLUNTEER_CONTACT_EMAILS[1]}?subject=Volunteering - Registration team`}
-                          className="text-link underline underline-offset-2 hover:text-white"
-                        >
-                          {VOLUNTEER_CONTACT_EMAILS[1]}
-                        </a>
-                        .
-                      </p>
-                    )}
                   </div>
                 </details>
               ))}
@@ -312,11 +292,14 @@ export default function VolunteerPage() {
               understand this before you submit.
             </p>
 
-            <ul className="mt-8 grid grid-cols-1 gap-3 md:grid-cols-2">
+            {/* Columns, not a grid. A two-column grid stretched every
+                one-line item to the height of its two-line neighbour and left
+                a hole in the last row; flowing them balances instead. */}
+            <ul className="mt-8 columns-1 gap-x-10 md:columns-2">
               {volunteerExpectations.map((item) => (
                 <li
                   key={item}
-                  className="flex items-start gap-3 rounded-xl border border-white/20 bg-white/5 p-4"
+                  className="mb-3 flex break-inside-avoid items-start gap-3"
                 >
                   <span
                     className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-gold"
@@ -340,21 +323,10 @@ export default function VolunteerPage() {
               </h2>
               <p className="mt-4 text-base leading-relaxed text-white/60">
                 Shortlisted volunteers are contacted for the next stage of
-                selection. The email will come from one of these addresses, so
-                check your spam folder for them:
+                selection. The email comes from a blockfestafrica.com address,
+                so check your spam folder for it, and everything after that
+                happens on WhatsApp.
               </p>
-              <ul className="mt-4 flex flex-col gap-1.5">
-                {VOLUNTEER_CONTACT_EMAILS.map((email) => (
-                  <li key={email} className="text-sm text-white/90">
-                    <a
-                      href={`mailto:${email}`}
-                      className="text-link underline underline-offset-2 hover:text-white"
-                    >
-                      {email}
-                    </a>
-                  </li>
-                ))}
-              </ul>
 
               <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-6">
                 <a

--- a/components/home/speakers.tsx
+++ b/components/home/speakers.tsx
@@ -2,6 +2,7 @@
 import type { EmblaOptionsType } from "embla-carousel";
 import Speakers from "../carousel";
 import { Button } from "../ui/button";
+import Link from "next/link";
 import { SpeakersList } from "@/lib/speakers";
 import { useSubtleAnimations } from "@/lib/hooks/use-subtle-animations";
 import { toast } from "sonner";
@@ -52,12 +53,11 @@ export function SpeakersSection() {
               Apply to Speak
             </Button>
             <Button
-              type="button"
+              asChild
               variant="outline"
-              onClick={() => toast("Coming soon!")}
-              className="cursor-pointer rounded-full px-7 text-base font-semibold"
+              className="rounded-full px-7 text-base font-semibold"
             >
-              Apply to Volunteer
+              <Link href="/volunteer">Apply to Volunteer</Link>
             </Button>
           </div>
         </div>

--- a/components/shared/footer.tsx
+++ b/components/shared/footer.tsx
@@ -23,6 +23,7 @@ const infoMenu: Menu[] = [
   { path: "/newsletter", title: "Newsletter" },
   { path: "/faq", title: "FAQ" },
   { path: "/travel", title: "Travel & Visa" },
+  { path: "/volunteer", title: "Volunteer" },
   { path: "/code-of-conduct", title: "Code of Conduct" },
   { path: `mailto:${CONTACT_EMAIL}`, title: "Contact" },
 ];

--- a/lib/volunteer.ts
+++ b/lib/volunteer.ts
@@ -1,0 +1,247 @@
+/**
+ * Volunteering for the current edition.
+ *
+ * Kept as data so the page stays readable and the departments can be checked
+ * against the application form. The form's dropdown and this list must agree:
+ * a department described here that a reader then cannot select is a dead end.
+ */
+
+export const VOLUNTEER_FORM_URL = "https://forms.gle/wBenVpKTA3uqHuyt9";
+
+/** The full roles document, which the form asks applicants to read first. */
+export const VOLUNTEER_ROLES_DOC_URL =
+  "https://docs.google.com/document/d/1E0da3ScdqivsazN-NZANHaCk5NHsELmN5FaA0iQ_fYY/edit?usp=sharing";
+
+/** Addresses a shortlisted volunteer may hear from. */
+export const VOLUNTEER_CONTACT_EMAILS = [
+  "zebulun@blockfestafrica.com",
+  "partnership@blockfestafrica.com",
+  "programs@blockfestafrica.com",
+] as const;
+
+export interface VolunteerDay {
+  date: string;
+  weekday: string;
+  title: string;
+  description: string;
+}
+
+/**
+ * Volunteering covers the two open days. The invitation-only Mixer on the 24th
+ * is not a volunteer shift.
+ */
+export const volunteerDays: VolunteerDay[] = [
+  {
+    date: "22 October",
+    weekday: "Thursday",
+    title: "Workshops, masterclasses and the deal room",
+    description:
+      "Technical and non-technical workshops and masterclasses from the morning, then a closed deal room for founders and investors later in the day.",
+  },
+  {
+    date: "23 October",
+    weekday: "Friday",
+    title: "Conference and exhibition",
+    description:
+      "The main conference and the exhibition floor, from the morning through to late afternoon.",
+  },
+];
+
+export interface VolunteerTeam {
+  id: string;
+  name: string;
+  purpose: string;
+  responsibilities: string[];
+  idealFor: string;
+  /** Which extra section of the form this team's applicants answer. */
+  assessment: "creative" | "operations";
+  /**
+   * Whether the application form currently lets someone pick this team. The
+   * roles document describes Registration; the form's dropdown does not offer
+   * it, so the page says so rather than sending people looking for it.
+   */
+  selectableInForm: boolean;
+}
+
+export const volunteerTeams: VolunteerTeam[] = [
+  {
+    id: "logistics",
+    name: "Logistics & Operations",
+    purpose: "Keep the event running smoothly behind the scenes.",
+    responsibilities: [
+      "Oversee venue setup and breakdown with vendors",
+      "Coordinate room readiness for speakers, press and sessions",
+      "Monitor event schedules and operational timelines with the programmes team",
+      "Test the registration flow and attendee movement plans before event week",
+      "Assist the event coordinator with on-site execution",
+      "Troubleshoot operational issues during the event",
+      "Coordinate inventory of event materials, merchandise, lanyards, badges and supplies",
+      "Support vendor logistics planning: delivery schedules, access points, loading bays",
+      "Coordinate movement of equipment between stages and workshop rooms",
+      "Support crowd flow and queue management",
+    ],
+    idealFor:
+      "Organised people who stay calm under pressure, are happy on their feet and notice detail.",
+    assessment: "operations",
+    selectableInForm: true,
+  },
+  {
+    id: "hospitality",
+    name: "Hospitality & Guest Experience",
+    purpose:
+      "Create an exceptional experience for every attendee, speaker, sponsor and VIP.",
+    responsibilities: [
+      "Greet attendees and direct them",
+      "Assist with lounge planning and guest flow design",
+      "Learn speaker profiles and sponsor expectations",
+      "Coordinate refreshments and catering support with vendors",
+      "Escort speakers and special guests",
+      "Handle guest enquiries and basic problem resolution",
+      "Keep networking areas functional and uncrowded",
+      "Monitor attendee comfort and experience",
+      "Manage stage transitions between speakers and hosts",
+      "Provide protocol support for speakers and VIPs",
+    ],
+    idealFor: "Friendly, confident communicators with strong people skills.",
+    assessment: "operations",
+    selectableInForm: true,
+  },
+  {
+    id: "registration",
+    name: "Registration",
+    purpose: "Get everyone checked in quickly and accurately.",
+    responsibilities: [
+      "Ticket verification",
+      "Badge printing and distribution",
+      "QR code scanning",
+      "Manage registration queues",
+      "Direct attendees after check-in",
+      "Handle accreditation for attendees, media, VIPs, guests, speakers, sponsors and team",
+    ],
+    idealFor:
+      "Fast learners who communicate well, stay organised and are comfortable with a crowd.",
+    assessment: "operations",
+    selectableInForm: false,
+  },
+  {
+    id: "technical",
+    name: "Stage & Technical Operations",
+    purpose:
+      "Support the technical delivery of every session and stage across both days.",
+    responsibilities: [
+      "Assist AV technicians",
+      "Manage microphones and stage equipment",
+      "Coordinate speaker slides",
+      "Session timing and countdown management",
+      "Workshop room technical assistance",
+      "Internet and equipment monitoring",
+    ],
+    idealFor:
+      "Technically inclined volunteers with AV, streaming or production experience.",
+    assessment: "operations",
+    selectableInForm: true,
+  },
+  {
+    id: "editorial",
+    name: "Editorial & Social Media",
+    purpose: "Tell the Blockf3st story in real time, before and during the event.",
+    responsibilities: [
+      "Live tweeting and thread writing",
+      "Instagram Stories and Reels support",
+      "Short-form vertical content capture",
+      "Speaker quote cards and real-time event updates",
+      "Community engagement online, and collecting attendee testimonials",
+      "Trend-based content during the event",
+      "Develop the social content calendar",
+      "Write posts across X, Instagram, LinkedIn, TikTok and Threads",
+      "Research trends and content opportunities",
+      "Produce speaker spotlights and founder features",
+      "Coordinate countdown campaigns and community engagement initiatives",
+      "Draft captions, threads and social copy",
+      "Plan live coverage strategy and content distribution workflows",
+      "Coordinate with the video and media teams for rapid content delivery",
+    ],
+    idealFor:
+      "Fast writers, skilled creators, community managers and social media natives.",
+    assessment: "creative",
+    selectableInForm: true,
+  },
+  {
+    id: "media",
+    name: "Media: Video & Photography",
+    purpose:
+      "Produce high-quality visual documentation and storytelling, and support media coverage.",
+    responsibilities: [
+      "Event photography and press room support",
+      "Coordinate interviews and organise photo and press requests",
+      "Collect media assets",
+      "Develop video concepts and storyboards, and plan promotional shoots",
+      "Film teaser campaigns, speaker announcements and countdown videos",
+      "Create sponsor and partner video content",
+      "Plan interview formats and build shot lists for event-day coverage",
+      "Coordinate equipment, crew schedules and editing workflows",
+      "Capture venue setup and behind-the-scenes production",
+      "Film keynotes, workshops, exhibitions and networking",
+      "Record interviews with founders, investors, speakers and attendees",
+      "Capture B-roll and social-first vertical content",
+      "Deliver same-day highlight videos and reels",
+    ],
+    idealFor: "Skilled videographers, editors and cinematographers.",
+    assessment: "creative",
+    selectableInForm: true,
+  },
+  {
+    id: "design",
+    name: "Design & Visual Assets",
+    purpose: "Produce the graphics that support event operations and content.",
+    responsibilities: [
+      "Develop brand visual identity and event branding designs",
+      "Emergency information graphics",
+      "Print-ready materials: merch, lanyards and more",
+      "Template management",
+      "Create speaker cards, sponsor assets and promotional graphics",
+      "Develop presentation templates",
+      "Design signage, maps, badges, lanyards and printed materials",
+      "Prepare exhibition and booth graphics",
+      "Create motion graphics for screens and stage visuals",
+    ],
+    idealFor:
+      "Skilled graphic, animation, motion, illustration and brand designers.",
+    assessment: "creative",
+    selectableInForm: true,
+  },
+  {
+    id: "exhibition",
+    name: "Exhibition & Partnership Support",
+    purpose:
+      "Support sponsors, exhibitors and partners from onboarding through to post-event reporting, so their activations actually work.",
+    responsibilities: [
+      "Support the partnerships team with sponsor and exhibitor onboarding",
+      "Collect brand assets, logos, booth requirements, activation details and technical needs",
+      "Track partner deliverables and outstanding requests",
+      "Assist with exhibition floor planning and booth allocation",
+      "Confirm booths have the furniture, branding, electricity, internet and other resources agreed",
+      "Help partners find storage, loading areas, meeting rooms and green rooms",
+      "Brief partner representatives on venue procedures and escalation points",
+      "Be the primary volunteer contact for assigned exhibitors and partners on event day",
+      "Coordinate with Hospitality when partners need refreshments or guest assistance",
+    ],
+    idealFor:
+      "Highly organised, professional and well-spoken people who can coordinate across teams and stay ahead of detail.",
+    assessment: "operations",
+    selectableInForm: true,
+  },
+];
+
+/** Asked of everyone, whichever team they land in. */
+export const volunteerExpectations = [
+  "Attend volunteer orientation and meetings",
+  "Arrive on time for every assigned shift",
+  "Wear the official Blockf3st volunteer badge and shirt",
+  "Keep a professional and respectful attitude",
+  "Communicate clearly with your team lead",
+  "Follow instructions from the Event Coordinator and Volunteer Operations team",
+  "Do not leave your assigned area without telling your lead",
+  "Protect confidential information about speakers, sponsors and attendees",
+  "Be ready for long hours, standing, walking and problem solving",
+];

--- a/lib/volunteer.ts
+++ b/lib/volunteer.ts
@@ -1,9 +1,9 @@
 /**
  * Volunteering for the current edition.
  *
- * Kept as data so the page stays readable and the departments can be checked
- * against the application form. The form's dropdown and this list must agree:
- * a department described here that a reader then cannot select is a dead end.
+ * Kept as data so the page stays readable and the departments stay in step with
+ * the application form. A department described here that a reader then cannot
+ * select on the form is a dead end, so the two lists must agree.
  */
 
 export const VOLUNTEER_FORM_URL = "https://forms.gle/wBenVpKTA3uqHuyt9";
@@ -55,12 +55,6 @@ export interface VolunteerTeam {
   idealFor: string;
   /** Which extra section of the form this team's applicants answer. */
   assessment: "creative" | "operations";
-  /**
-   * Whether the application form currently lets someone pick this team. The
-   * roles document describes Registration; the form's dropdown does not offer
-   * it, so the page says so rather than sending people looking for it.
-   */
-  selectableInForm: boolean;
 }
 
 export const volunteerTeams: VolunteerTeam[] = [
@@ -83,7 +77,6 @@ export const volunteerTeams: VolunteerTeam[] = [
     idealFor:
       "Organised people who stay calm under pressure, are happy on their feet and notice detail.",
     assessment: "operations",
-    selectableInForm: true,
   },
   {
     id: "hospitality",
@@ -104,7 +97,6 @@ export const volunteerTeams: VolunteerTeam[] = [
     ],
     idealFor: "Friendly, confident communicators with strong people skills.",
     assessment: "operations",
-    selectableInForm: true,
   },
   {
     id: "registration",
@@ -121,7 +113,6 @@ export const volunteerTeams: VolunteerTeam[] = [
     idealFor:
       "Fast learners who communicate well, stay organised and are comfortable with a crowd.",
     assessment: "operations",
-    selectableInForm: false,
   },
   {
     id: "technical",
@@ -139,7 +130,6 @@ export const volunteerTeams: VolunteerTeam[] = [
     idealFor:
       "Technically inclined volunteers with AV, streaming or production experience.",
     assessment: "operations",
-    selectableInForm: true,
   },
   {
     id: "editorial",
@@ -164,7 +154,6 @@ export const volunteerTeams: VolunteerTeam[] = [
     idealFor:
       "Fast writers, skilled creators, community managers and social media natives.",
     assessment: "creative",
-    selectableInForm: true,
   },
   {
     id: "media",
@@ -188,7 +177,6 @@ export const volunteerTeams: VolunteerTeam[] = [
     ],
     idealFor: "Skilled videographers, editors and cinematographers.",
     assessment: "creative",
-    selectableInForm: true,
   },
   {
     id: "design",
@@ -208,7 +196,6 @@ export const volunteerTeams: VolunteerTeam[] = [
     idealFor:
       "Skilled graphic, animation, motion, illustration and brand designers.",
     assessment: "creative",
-    selectableInForm: true,
   },
   {
     id: "exhibition",
@@ -229,7 +216,6 @@ export const volunteerTeams: VolunteerTeam[] = [
     idealFor:
       "Highly organised, professional and well-spoken people who can coordinate across teams and stay ahead of detail.",
     assessment: "operations",
-    selectableInForm: true,
   },
 ];
 


### PR DESCRIPTION
`/volunteer` — the full call, with the form hyperlinked throughout.

## Layout

The roles document is eight departments and well over a hundred responsibilities. Flat, that is a wall nobody finishes — and the form asks people to read it *before* applying, so it has to be readable.

Each department collapses to **its purpose and who it suits**, and opens to the full responsibility list plus "ideal for". Native `<details>`, which means it works with JavaScript off and a browser's find-in-page still reaches inside a closed one — a real consideration when someone is scanning for "AV" or "photography".

Page order: the ask → the two days → the eight departments → what the form will ask → what is expected of everyone → apply.

## The page carries what the form does not

Before you open the form, it tells you:

- **Creative applicants** are asked for three links to previous work
- **Operations applicants** are asked to describe a time they solved a problem under pressure
- **Everyone** needs a phone number that works on WhatsApp, because everything after selection happens there

That is the difference between a considered answer and an improvised one. It also names **all three addresses** a selection email can come from, so they are not lost to a spam folder.

## ⚠️ One inconsistency the page had to be honest about

**The roles document describes a Registration team. The form's department dropdown does not offer it.**

Describing a team and then leaving the reader hunting for it in the form is a dead end, so that card is marked *"Not yet on the form"* and says to apply under Logistics and mention Registration, or email partnerships.

This is **data, not copy** — `selectableInForm` on the team — so it disappears by flipping one flag once the form catches up. Worth adding to the form; the roles doc treats it as a real team with six responsibilities.

**Also spotted:** the form's dropdown reads *"Exhibition and patner support"* — missing the "r" in partner. Page spells it correctly.

## Dates

Volunteering covers **22 and 23 October only**. Your roles doc says two days, which matches: the Mixer on the 24th is invitation-only and is not a volunteer shift.

## Wiring

- The homepage **Apply to Volunteer** button stops toasting "coming soon" and links here. Verified it navigates, is a 44px target, and is a plain anchor rather than an invalid nested `<a><button>`.
- `/volunteer` added to the footer nav, the sitemap, and `llms.txt` — so an assistant asked "how do I volunteer at Blockfest" has an answer.

## Verification

Production build, 56 pages. Content: form link, roles doc link, all 8 departments, 8 native `<details>`, responsibilities present in the DOM, all 3 contact emails, both days, expectations, WhatsApp note. Layout at 390px and 1280px: 0 overflow, one `h1`, no heading skips, no element escaping its parent, no sub-44px targets, collapsibles open correctly. 134/134 tests, tsc and biome clean, all routes 200.

## Two things still on your side

1. **Add Registration to the form**, or tell me it is deliberate and I will remove the card.
2. **The form has no stated deadline and no target number.** I asked earlier and it was not in what you sent, so the page does not invent urgency. If there is a cut-off, send it and I will add it — a deadline meaningfully changes how many people finish an application.