### PR TITLE
Add /call-for-speakers (re-targeted to main)

### DIFF
--- a/app/call-for-speakers/page.tsx
+++ b/app/call-for-speakers/page.tsx
@@ -16,7 +16,7 @@ const EVENT = CURRENT_EDITION;
 
 export const metadata: Metadata = {
   title: "Call for Speakers | Blockf3st Africa '26 Lagos",
-  description: `Speaker applications for ${EVENT.name}, ${EVENT.date.displayDate}. Keynotes, panels, fireside chats and lightning talks across six tracks spanning AI, blockchain, policy, capital, infrastructure, culture and careers.`,
+  description: `Speaker applications for ${EVENT.name}, ${EVENT.date.displayDate}. Keynotes, panels, fireside chats, lightning talks and hands-on workshops across six tracks spanning AI, blockchain, policy, capital, infrastructure, culture and careers.`,
   keywords: [
     "blockfest africa call for speakers",
     "speak at blockfest",
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
   ],
   openGraph: {
     title: "Call for Speakers | Blockf3st Africa '26 Lagos",
-    description: `Pitch a session for ${EVENT.name}. Six tracks, four formats, one stage in Lagos.`,
+    description: `Pitch a session for ${EVENT.name}. Six tracks, six formats, two days in Lagos.`,
   },
   alternates: { canonical: `${SITE_URL}/call-for-speakers` },
 };
@@ -61,24 +61,37 @@ export default function CallForSpeakersPage() {
         {/* ---------- The ask ---------- */}
         <section className="section-y bg-ground">
           <div className="container-page">
-            <p className="eyebrow text-white/60">Call for speakers</p>
-            <h1 className="text-display-sm mt-3 max-w-3xl font-bold text-white">
-              Take the stage in Lagos
-            </h1>
-            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
-              {speakingDays}. This year&rsquo;s theme is{" "}
-              <span className="font-semibold text-white">
-                {EVENT.tagline}
-              </span>{" "}
-              — what it takes to move African work onto open rails, and what
-              changes once it is there.
-            </p>
-            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
-              We are looking for builders, operators, investors, policymakers
-              and creators with something specific to say. A talk about one
-              thing you have actually done beats a survey of a field, and we
-              would rather hear a real disagreement than a safe consensus.
-            </p>
+            {/* One column on a phone, two from lg. Capping the copy at
+                max-w-2xl and stacking it left leaves half a desktop empty,
+                and widening the column instead would push line length past
+                what is comfortable to read. Same 12-column shape the ticket
+                hero uses. */}
+            <div className="grid gap-x-12 gap-y-6 lg:grid-cols-12 lg:items-start">
+              <div className="lg:col-span-6">
+                <p className="eyebrow text-white/60">Call for speakers</p>
+                <h1 className="text-display-sm mt-3 font-bold text-white">
+                  Take the stage in Lagos
+                </h1>
+              </div>
+
+              <div className="lg:col-span-6 lg:pt-2">
+                <p className="max-w-xl text-base leading-relaxed text-white/60 lg:max-w-none">
+                  {speakingDays}. This year&rsquo;s theme is{" "}
+                  <span className="font-semibold text-white">
+                    {EVENT.tagline}
+                  </span>
+                  . What it takes to move African work onto open rails, and
+                  what changes once it is there.
+                </p>
+                <p className="mt-4 max-w-xl text-base leading-relaxed text-white/60 lg:max-w-none">
+                  We are looking for builders, operators, investors,
+                  policymakers and creators with something specific to say. A
+                  talk about one thing you have actually done beats a survey of
+                  a field, and we would rather hear a real disagreement than a
+                  safe consensus.
+                </p>
+              </div>
+            </div>
 
             {/* The form asks for a bio, a headshot and a written session
                 description in one sitting. The apply control sits at the foot
@@ -102,12 +115,13 @@ export default function CallForSpeakersPage() {
         >
           <div className="container-page">
             <h2 className="text-display-sm font-bold text-white">
-              Four formats
+              {sessionFormats.length} formats
             </h2>
             <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
               Pick the one that fits the idea, not the one that sounds most
               senior. A sharp seven minutes is often worth more than a keynote
-              stretched to fill its slot.
+              stretched to fill its slot, and a workshop people leave having
+              built something beats both.
             </p>
 
             <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2">

--- a/app/call-for-speakers/page.tsx
+++ b/app/call-for-speakers/page.tsx
@@ -1,0 +1,286 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ChevronDown, Mic, Users } from "lucide-react";
+import { lagos2026Tracks } from "@/lib/events";
+import {
+  applicationChecklist,
+  isSpeakerFormOpen,
+  sessionFormats,
+  speakerTerms,
+  speakingDays,
+} from "@/lib/speaking";
+import { SpeakerApplyCTA } from "@/components/speakers/apply-cta";
+import { CURRENT_EDITION, EVENT_ID, SITE_URL } from "@/lib/seo-event";
+
+const EVENT = CURRENT_EDITION;
+
+export const metadata: Metadata = {
+  title: "Call for Speakers | Blockf3st Africa '26 Lagos",
+  description: `Speaker applications for ${EVENT.name}, ${EVENT.date.displayDate}. Keynotes, panels, fireside chats and lightning talks across six tracks spanning AI, blockchain, policy, capital, infrastructure, culture and careers.`,
+  keywords: [
+    "blockfest africa call for speakers",
+    "speak at blockfest",
+    "africa tech conference speakers 2026",
+    "web3 ai speaker application lagos",
+    "call for papers africa tech",
+  ],
+  openGraph: {
+    title: "Call for Speakers | Blockf3st Africa '26 Lagos",
+    description: `Pitch a session for ${EVENT.name}. Six tracks, four formats, one stage in Lagos.`,
+  },
+  alternates: { canonical: `${SITE_URL}/call-for-speakers` },
+};
+
+/**
+ * The call for speakers.
+ *
+ * Written to be read before the form exists. Last year's application asked for
+ * a headshot, a bio, a 100 to 200 word session description and a line on how
+ * the topic meets the theme, all in one sitting — so this page says that up
+ * front, and the apply control announces itself rather than pretending to work.
+ */
+export default function CallForSpeakersPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD requires raw script injection
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "WebPage",
+            name: "Call for Speakers",
+            url: `${SITE_URL}/call-for-speakers`,
+            about: { "@id": EVENT_ID },
+            description: `Speaker applications for ${EVENT.name} on ${EVENT.date.displayDate}.`,
+          }),
+        }}
+      />
+
+      <main id="main">
+        {/* ---------- The ask ---------- */}
+        <section className="section-y bg-ground">
+          <div className="container-page">
+            <p className="eyebrow text-white/60">Call for speakers</p>
+            <h1 className="text-display-sm mt-3 max-w-3xl font-bold text-white">
+              Take the stage in Lagos
+            </h1>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+              {speakingDays}. This year&rsquo;s theme is{" "}
+              <span className="font-semibold text-white">
+                {EVENT.tagline}
+              </span>{" "}
+              — what it takes to move African work onto open rails, and what
+              changes once it is there.
+            </p>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+              We are looking for builders, operators, investors, policymakers
+              and creators with something specific to say. A talk about one
+              thing you have actually done beats a survey of a field, and we
+              would rather hear a real disagreement than a safe consensus.
+            </p>
+
+            {/* The form asks for a bio, a headshot and a written session
+                description in one sitting. The apply control sits at the foot
+                of the page so a reader meets that list before the button. */}
+            <div className="mt-8">
+              <a
+                href="#formats"
+                className="inline-flex min-h-12 items-center gap-2 rounded-full border border-white/20 px-7 text-base font-semibold text-white transition-colors duration-300 hover:bg-white/10"
+              >
+                What we are looking for
+                <ChevronDown className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </div>
+          </div>
+        </section>
+
+        {/* ---------- Formats ---------- */}
+        <section
+          id="formats"
+          className="section-y bg-ground border-t border-white/20"
+        >
+          <div className="container-page">
+            <h2 className="text-display-sm font-bold text-white">
+              Four formats
+            </h2>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+              Pick the one that fits the idea, not the one that sounds most
+              senior. A sharp seven minutes is often worth more than a keynote
+              stretched to fill its slot.
+            </p>
+
+            <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2">
+              {sessionFormats.map((format) => (
+                <div
+                  key={format.name}
+                  className="rounded-xl border border-white/20 bg-white/5 p-6 transition-colors duration-300 hover:bg-white/10"
+                >
+                  <span className="mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-brand-blue/15 text-brand-blue-light">
+                    <Mic className="h-5 w-5" aria-hidden="true" />
+                  </span>
+                  <div className="flex flex-wrap items-baseline gap-x-3">
+                    <h3 className="text-lg font-bold text-white lg:text-2xl">
+                      {format.name}
+                    </h3>
+                    <span className="eyebrow text-brand-gold">
+                      {format.length}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm leading-relaxed text-white/60 lg:text-base">
+                    {format.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ---------- Tracks ---------- */}
+        <section className="section-y bg-ground border-t border-white/20">
+          <div className="container-page">
+            <h2 className="text-display-sm font-bold text-white">
+              {lagos2026Tracks.length} tracks
+            </h2>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+              The application asks which one your session belongs to. If it sits
+              across two, say so and say why.
+            </p>
+
+            <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {lagos2026Tracks.map((track) => (
+                <div
+                  key={track.title}
+                  className="rounded-xl border border-white/20 bg-white/5 p-6"
+                >
+                  <h3 className="text-lg font-bold text-white">
+                    {track.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-relaxed text-white/60">
+                    {track.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ---------- What to prepare ---------- */}
+        <section className="section-y bg-ground border-t border-white/20">
+          <div className="container-page">
+            <h2 className="text-display-sm font-bold text-white">
+              Have these ready
+            </h2>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+              The form asks for all of it in one sitting, and there is no saving
+              halfway. Twenty minutes gathering this first is the difference
+              between a considered application and an abandoned one.
+            </p>
+
+            <div className="mt-8 flex flex-col gap-4">
+              {applicationChecklist.map((item, index) => (
+                <div
+                  key={item.title}
+                  className="flex items-start gap-5 rounded-xl border border-white/20 bg-white/5 p-5 sm:p-6"
+                >
+                  <span
+                    className="eyebrow mt-0.5 shrink-0 tabular-nums text-brand-gold"
+                    aria-hidden="true"
+                  >
+                    {String(index + 1).padStart(2, "0")}
+                  </span>
+                  <div className="min-w-0">
+                    <h3 className="text-base font-bold text-white lg:text-lg">
+                      {item.title}
+                    </h3>
+                    <p className="mt-2 text-sm leading-relaxed text-white/60 lg:text-base">
+                      {item.detail}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ---------- Terms ---------- */}
+        <section className="section-y bg-ground border-t border-white/20">
+          <div className="container-page">
+            <h2 className="text-display-sm font-bold text-white">
+              Before you apply
+            </h2>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
+              The form asks you to agree to each of these, so none of it should
+              be a surprise when you get there.
+            </p>
+
+            <ul className="mt-8 columns-1 gap-x-10 lg:columns-2">
+              {speakerTerms.map((term) => (
+                <li
+                  key={term}
+                  className="mb-3 flex break-inside-avoid items-start gap-3"
+                >
+                  <span
+                    className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-gold"
+                    aria-hidden="true"
+                  />
+                  <span className="text-sm leading-relaxed text-white/60 lg:text-base">
+                    {term}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        {/* ---------- Apply ---------- */}
+        <section className="section-y bg-ground border-t border-white/20">
+          <div className="container-page">
+            <div className="max-w-2xl">
+              <span className="mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-brand-blue/15 text-brand-blue-light">
+                <Users className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <h2 className="text-display-sm font-bold text-white">
+                {isSpeakerFormOpen ? "Apply" : "Applications open soon"}
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-white/60">
+                {isSpeakerFormOpen
+                  ? "Sessions are selected on the strength of the idea and the fit with the programme, not on follower count."
+                  : "The form is not live yet. Get what is above ready now and you will be able to submit in one sitting when it opens. We announce it on X first."}
+              </p>
+
+              <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-6">
+                <SpeakerApplyCTA />
+                <Link
+                  href="/speakers"
+                  className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-link underline underline-offset-4 hover:text-white"
+                >
+                  See who has spoken before
+                </Link>
+              </div>
+
+              <p className="mt-8 text-sm leading-relaxed text-white/60">
+                Coming in from outside Lagos?{" "}
+                <Link
+                  href="/travel"
+                  className="text-link underline underline-offset-2 hover:text-white"
+                >
+                  Getting to Lagos
+                </Link>{" "}
+                covers the venue, visas and accommodation. Not a speaker but
+                still want in?{" "}
+                <Link
+                  href="/volunteer"
+                  className="text-link underline underline-offset-2 hover:text-white"
+                >
+                  Volunteering is open
+                </Link>
+                .
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -48,7 +48,7 @@ export function GET() {
             : "";
           const days = t.days.map((d) => `${d.label} (${d.date})`).join("; ");
           const note = t.note ? ` ${t.note}` : "";
-          return `  - ${t.name} — ${price}. ${days}. ${t.bestFor}${excludes}${note}`;
+          return `  - ${t.name}: ${price}. ${days}. ${t.bestFor}${excludes}${note}`;
         })
         .join("\n");
       return `${group.title}: ${group.description}\n${rows}`;
@@ -95,13 +95,13 @@ ${TICKET_PLATFORM_URL} is the official ticket platform.
 
 ## Pages
 
-- ${SITE_URL}/ — the event, the programme and how to get in
-- ${SITE_URL}/tickets — all ${ticketTiers.length} passes, prices and inclusions
-- ${SITE_URL}/faq — pricing, refunds, meals, transport, accessibility
-- ${SITE_URL}/speakers — past speakers; the ${e.year} lineup is announced in the coming weeks
-- ${SITE_URL}/schedule — the ${past.year} programme; the ${e.year} schedule is published in the coming weeks
-- ${SITE_URL}/blockfest-2025 — recap of ${past.name}
-- ${SITE_URL}/blockfest-south-africa-2026 — recap of the Cape Town roadshow, May 2026
+- ${SITE_URL}/: the event, the programme and how to get in
+- ${SITE_URL}/tickets: all ${ticketTiers.length} passes, prices and inclusions
+- ${SITE_URL}/faq: pricing, refunds, meals, transport, accessibility
+- ${SITE_URL}/speakers: past speakers; the ${e.year} lineup is announced in the coming weeks
+- ${SITE_URL}/schedule: the ${past.year} programme; the ${e.year} schedule is published in the coming weeks
+- ${SITE_URL}/blockfest-2025: recap of ${past.name}
+- ${SITE_URL}/blockfest-south-africa-2026: recap of the Cape Town roadshow, May 2026
 
 ## Previous editions
 

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,4 +1,4 @@
-import { blockfest2026Lagos, blockfest2025Lagos } from "@/lib/events";
+import { blockfest2026Lagos, blockfest2025Lagos, lagos2026Tracks } from "@/lib/events";
 import {
   ticketGroups,
   ticketTiers,
@@ -11,6 +11,7 @@ import {
 } from "@/lib/tickets";
 import { SITE_URL } from "@/lib/seo-event";
 import { volunteerTeams } from "@/lib/volunteer";
+import { isSpeakerFormOpen } from "@/lib/speaking";
 
 /**
  * /llms.txt — a plain-text brief for AI clients and agents.
@@ -78,6 +79,8 @@ export function GET() {
 - Volunteering: applications are open across ${volunteerTeams.length} departments for
   22 and 23 October. Roles, what each team does and the application form are at
   ${SITE_URL}/volunteer
+- Speaking: the call for speakers is at ${SITE_URL}/call-for-speakers. Four session
+  formats across ${lagos2026Tracks.length} tracks. ${isSpeakerFormOpen ? "Applications are open." : "The application form is not open yet."}
 
 ## Tickets
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -60,6 +60,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     },
     {
+      url: `${baseUrl}/call-for-speakers`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/volunteer`,
       lastModified: new Date(),
       changeFrequency: "weekly",

--- a/components/home/speakers.tsx
+++ b/components/home/speakers.tsx
@@ -5,7 +5,6 @@ import { Button } from "../ui/button";
 import Link from "next/link";
 import { SpeakersList } from "@/lib/speakers";
 import { useSubtleAnimations } from "@/lib/hooks/use-subtle-animations";
-import { toast } from "sonner";
 import "./subtle-animations.css";
 
 /* The homepage carousel is a taster; /speakers has the full list. Rendering all
@@ -45,12 +44,11 @@ export function SpeakersSection() {
           </p>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
             <Button
-              type="button"
+              asChild
               variant="gold"
-              onClick={() => toast("Coming soon!")}
-              className="cursor-pointer rounded-full px-7 text-base font-semibold"
+              className="rounded-full px-7 text-base font-semibold"
             >
-              Apply to Speak
+              <Link href="/call-for-speakers">Apply to Speak</Link>
             </Button>
             <Button
               asChild

--- a/components/shared/footer.tsx
+++ b/components/shared/footer.tsx
@@ -23,6 +23,7 @@ const infoMenu: Menu[] = [
   { path: "/newsletter", title: "Newsletter" },
   { path: "/faq", title: "FAQ" },
   { path: "/travel", title: "Travel & Visa" },
+  { path: "/call-for-speakers", title: "Call for Speakers" },
   { path: "/volunteer", title: "Volunteer" },
   { path: "/code-of-conduct", title: "Code of Conduct" },
   { path: `mailto:${CONTACT_EMAIL}`, title: "Contact" },

--- a/components/speakers/apply-cta.tsx
+++ b/components/speakers/apply-cta.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { ArrowUpRight } from "lucide-react";
+import { toast } from "sonner";
+import { isSpeakerFormOpen, SPEAKER_FORM_URL } from "@/lib/speaking";
+
+/**
+ * The apply control.
+ *
+ * Renders as a real link the moment SPEAKER_FORM_URL is set, and until then as
+ * a button that says so rather than a dead anchor or a disabled control with no
+ * explanation. Keeping both in one place means opening applications is a
+ * one-line change in lib/speaking.ts, not an edit across the page.
+ */
+export function SpeakerApplyCTA({
+  children = "Apply to speak",
+  className = "",
+}: {
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  const base =
+    "inline-flex min-h-12 items-center gap-2 rounded-full bg-brand-gold px-8 text-base font-semibold text-black transition-colors duration-300 hover:bg-brand-gold-hover";
+
+  if (isSpeakerFormOpen && SPEAKER_FORM_URL) {
+    return (
+      <a
+        href={SPEAKER_FORM_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${base} ${className}`}
+      >
+        {children}
+        <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        toast("Applications open soon", {
+          description:
+            "The form is not live yet. Follow @blockfestafrica and we will announce it there first.",
+        })
+      }
+      className={`${base} cursor-pointer ${className}`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/lib/speaking.ts
+++ b/lib/speaking.ts
@@ -19,7 +19,7 @@ export interface SessionFormat {
   description: string;
 }
 
-/** The four formats the application asks you to pick between. */
+/** The formats the application asks you to pick between. */
 export const sessionFormats: SessionFormat[] = [
   {
     name: "Keynote",
@@ -44,6 +44,18 @@ export const sessionFormats: SessionFormat[] = [
     length: "Under 7 minutes",
     description:
       "One idea, sharply made, no room to warm up. Often the most memorable thing on a programme.",
+  },
+  {
+    name: "Technical workshop",
+    length: "Day 1, hands on",
+    description:
+      "People leave having built something. Bring the repo, the dataset or the contract, and expect a room that wants to follow along rather than watch.",
+  },
+  {
+    name: "Non-technical workshop",
+    length: "Day 1, hands on",
+    description:
+      "The same shape without the terminal. Fundraising, go to market, design, policy, storytelling: anything people can practise in the room and use on Monday.",
   },
 ];
 

--- a/lib/speaking.ts
+++ b/lib/speaking.ts
@@ -1,0 +1,88 @@
+import { blockfest2026Lagos } from "./events";
+
+/**
+ * The call for speakers.
+ *
+ * The form is not open yet. `SPEAKER_FORM_URL` is the only switch: set it and
+ * the page stops saying "opening soon" and starts linking, everywhere at once.
+ * Nothing else needs editing.
+ */
+export const SPEAKER_FORM_URL: string | null = null;
+
+export const isSpeakerFormOpen = SPEAKER_FORM_URL !== null;
+
+const EVENT = blockfest2026Lagos;
+
+export interface SessionFormat {
+  name: string;
+  length: string;
+  description: string;
+}
+
+/** The four formats the application asks you to pick between. */
+export const sessionFormats: SessionFormat[] = [
+  {
+    name: "Keynote",
+    length: "Main stage",
+    description:
+      "One person, one argument, the room's full attention. For a thesis you have earned the right to make.",
+  },
+  {
+    name: "Panel discussion",
+    length: "Moderated",
+    description:
+      "Three or four voices on a question that genuinely divides them. Bring the disagreement, not the consensus.",
+  },
+  {
+    name: "Fireside chat",
+    length: "Conversational",
+    description:
+      "A longer, less formal conversation. Best when the story behind the work is the interesting part.",
+  },
+  {
+    name: "Lightning talk",
+    length: "Under 7 minutes",
+    description:
+      "One idea, sharply made, no room to warm up. Often the most memorable thing on a programme.",
+  },
+];
+
+/** Prepared in advance, because the form asks for all of it in one sitting. */
+export const applicationChecklist = [
+  {
+    title: "A session title and description",
+    detail:
+      "100 to 200 words on what you will actually say. Specific beats broad: a talk about one thing you have done lands better than a survey of a field.",
+  },
+  {
+    title: "Your bio",
+    detail: "100 to 150 words, written in the third person.",
+  },
+  {
+    title: "A recent professional headshot",
+    detail:
+      "Used on the site and in promotion if you are selected, so send the one you would be happy to see on a banner.",
+  },
+  {
+    title: "Your links",
+    detail:
+      "LinkedIn or a personal site, and your X handle. Plus one to three events you have spoken at, with the topic and year, if you have them.",
+  },
+  {
+    title: "Who it is for",
+    detail:
+      "Which audiences the session serves, and which track it belongs to. Both are on the form.",
+  },
+];
+
+/** Stated plainly, because all four are consent questions on the form. */
+export const speakerTerms = [
+  "Applying does not guarantee a speaking slot.",
+  `If selected, your name, bio, session title and headshot may be used on the site, in promotional material and on social media.`,
+  "Sessions are recorded and photographed, and may be published or shared online afterwards.",
+  "The team will contact you by email or phone about your application, and about logistics if you are selected.",
+  "The form asks whether you can cover your own travel and accommodation if you are coming from outside Lagos.",
+];
+
+/** Both days carry sessions, so a proposal can be for either. */
+export const speakingDays = `${EVENT.date.displayDate.replace(/,\s*\d{4}$/, "")}, ${EVENT.location.venue}`;


### PR DESCRIPTION
Re-opening #25 against `main`.

**#25 was stacked on #24** and GitHub merged it into `feat/volunteer-page` rather than into `main`. #24 had already landed by then, so those two commits never reached main and `/call-for-speakers` is not live. Same branch, same commits, correct base this time.

Verified it merges into main with **zero conflicts**.

## What it brings

The call for speakers page, built from last year's form and updated to this edition, plus the follow-up commit with your three changes:

- **Six formats**, including technical and non-technical workshops — Day 1 is workshops and masterclasses, so a call asking only for stage sessions was asking for half the programme. The heading counts the array rather than hardcoding a number.
- **Em dashes removed** from everything a reader or AI client sees. One in the hero, seventeen in `llms.txt`. Verified zero across all ten pages and `llms.txt`.
- **The hero spreads on wide screens** — two columns from `lg`, matching the ticket hero. Line length improves from ~84 to ~65 characters at 1280px while using the full width, rather than trading one for the other.

Plus: `SPEAKER_FORM_URL` in `lib/speaking.ts` is the single switch that turns the coming-soon toast into a live link, the homepage "Apply to Speak" button links here instead of toasting, and the page is in the footer, sitemap and `llms.txt`.

Everything was verified on the branch before: 57 pages, 134/134 tests, tsc and biome clean, 0 overflow at 390 and 1280, one `h1`, no heading skips, toast fires, homepage button navigates.