### PR TITLE
Track the ticket funnel on our own site (Phase 1)

### DIFF
--- a/app/tickets/page.tsx
+++ b/app/tickets/page.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { TicketHero } from "@/components/tickets/ticket-hero";
+import { TicketsPageView } from "@/components/tickets/tickets-page-view";
 import { TicketAbout } from "@/components/tickets/ticket-about";
 import { VenueVideo, VENUE_VIDEO } from "@/components/tickets/venue-video";
 import { TicketProof } from "@/components/tickets/ticket-proof";
@@ -105,6 +106,8 @@ const TicketsPage = () => {
   return (
     <>
       <TicketOffersSchema />
+
+      <TicketsPageView />
 
       <main id="main">
         {/* Secure your seat — early bird countdown + primary CTA */}

--- a/components/home/hero-2026.tsx
+++ b/components/home/hero-2026.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { ArrowRight, Calendar, CalendarPlus, MapPin } from "lucide-react";
 import { Button } from "../ui/button";
-import { trackButtonClick, trackTicketIntent } from "@/lib/sabilytics";
+import { trackButtonClick } from "@/lib/sabilytics";
 import { blockfest2026Lagos } from "@/lib/events";
 import { calculateTimeLeft, type TimeLeft } from "@/lib/countdown";
 import { EARLY_BIRD_ENDS } from "@/lib/tickets";
@@ -37,10 +37,6 @@ function EarlyBirdLine() {
 }
 
 export function HeroSection2026() {
-
-  const handleTickets = () => {
-    trackTicketIntent("hero-cta");
-  };
 
   return (
     <section className="relative isolate overflow-hidden bg-ground">
@@ -103,7 +99,7 @@ export function HeroSection2026() {
               variant="gold"
               className="rounded-full px-7 text-base font-semibold"
             >
-              <Link href="/tickets" onClick={handleTickets}>
+              <Link href="/tickets">
                 Get Tickets
                 <ArrowRight className="h-4 w-4" aria-hidden="true" />
               </Link>

--- a/components/home/partners.tsx
+++ b/components/home/partners.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Button } from "../ui/button";
 import React from "react";
-import { trackButtonClick, trackTicketIntent } from "@/lib/sabilytics";
+import { trackButtonClick } from "@/lib/sabilytics";
 import { useSubtleAnimations } from "@/lib/hooks/use-subtle-animations";
 import { CONTACT_EMAIL } from "@/lib/constants";
 import "./subtle-animations.css";

--- a/components/home/sponsorship.tsx
+++ b/components/home/sponsorship.tsx
@@ -2,7 +2,7 @@
 import Link from "next/link";
 import { Mail } from "lucide-react";
 import { useSubtleAnimations } from "@/lib/hooks/use-subtle-animations";
-import { trackButtonClick, trackTicketIntent } from "@/lib/sabilytics";
+import { trackButtonClick } from "@/lib/sabilytics";
 import { FaTelegram } from "react-icons/fa6";
 import { CONTACT_EMAIL } from "@/lib/constants";
 import "./subtle-animations.css";

--- a/components/shared/announcement-bar.tsx
+++ b/components/shared/announcement-bar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
-import { trackButtonClick, trackTicketIntent } from "@/lib/sabilytics";
+import { trackButtonClick } from "@/lib/sabilytics";
 import { hasPassed } from "@/lib/countdown";
 import { EARLY_BIRD_ENDS, formatNaira, lowestTicketPrice } from "@/lib/tickets";
 

--- a/components/shared/footer.tsx
+++ b/components/shared/footer.tsx
@@ -7,7 +7,7 @@ import type { Menu } from "@/types";
 import { gotham } from "@/lib/fonts";
 import { CONTACT_EMAIL, SOCIAL_URLS } from "@/lib/constants";
 import { useRouter, usePathname } from "next/navigation";
-import { trackButtonClick, trackTicketIntent } from "@/lib/sabilytics";
+import { trackButtonClick } from "@/lib/sabilytics";
 import { Newsletter } from "./newsletter";
 
 const exploreMenu: Menu[] = [

--- a/components/tickets/ticket-cta.tsx
+++ b/components/tickets/ticket-cta.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { trackTicketIntent } from "@/lib/sabilytics";
+import { trackCheckoutStarted, withHandoff } from "@/lib/sabilytics";
 import { ArrowRight } from "lucide-react";
 import { ticketUrl } from "@/lib/tickets";
 import { cn } from "@/lib/utils";
@@ -8,6 +8,9 @@ import { cn } from "@/lib/utils";
 interface TicketCTAProps {
   /** Which tier or section the click came from — sent to analytics. */
   source: string;
+  /** The tier, when this button sells a specific one. Lets one pass be
+      compared against another inside the same campaign. */
+  pass?: string;
   children: React.ReactNode;
   variant?: "gold" | "outline";
   className?: string;
@@ -16,25 +19,43 @@ interface TicketCTAProps {
 /** Links out to the ticket platform and records the click. */
 export function TicketCTA({
   source,
+  pass,
   children,
   variant = "gold",
   className,
 }: TicketCTAProps) {
-
   const styles =
     variant === "gold"
       ? "bg-brand-gold text-black hover:bg-brand-gold-hover"
       : "bg-white/10 text-white border border-white/20 hover:bg-white/20";
+
+  /**
+   * Rewrite the href just before the browser follows it.
+   *
+   * The server renders a plain URL carrying the UTMs, which is what a visitor
+   * with JavaScript off or the tracker blocked will use, so the link always
+   * works. This upgrades it in place, on the interaction that is about to
+   * navigate, rather than calling preventDefault and re-opening the window:
+   * that keeps target="_blank" out of popup-blocker territory and leaves the
+   * native middle-click and open-in-new-tab behaviour alone.
+   *
+   * pointerdown covers mouse and touch; focus covers keyboard, since it fires
+   * before Enter activates the link.
+   */
+  const upgradeHref = (el: HTMLAnchorElement) => {
+    const upgraded = withHandoff(ticketUrl(source));
+    if (upgraded !== el.href) el.href = upgraded;
+  };
 
   return (
     <a
       href={ticketUrl(source)}
       target="_blank"
       rel="noopener noreferrer"
+      onPointerDown={(e) => upgradeHref(e.currentTarget)}
+      onFocus={(e) => upgradeHref(e.currentTarget)}
       onClick={() => {
-        // One beacon, not two. These fired together on every click, costing
-        // 11.3ms of a 16.6ms handler and doubling the request count.
-        trackTicketIntent(source);
+        trackCheckoutStarted(source, pass);
       }}
       className={cn(
         "inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 font-semibold transition-colors duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light",

--- a/components/tickets/ticket-tiers.tsx
+++ b/components/tickets/ticket-tiers.tsx
@@ -108,6 +108,7 @@ function TierCard({ tier }: { tier: TicketTier }) {
       <div className="mt-auto pt-6">
         <TicketCTA
           source={`Tickets Page - ${tier.name}`}
+          pass={tier.id}
           variant={tier.featured ? "gold" : "outline"}
           className="w-full"
         >

--- a/components/tickets/tickets-page-view.tsx
+++ b/components/tickets/tickets-page-view.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { trackTicketsPageViewed } from "@/lib/sabilytics";
+
+/**
+ * The first step of the ticket funnel.
+ *
+ * The tracker already records a pageview on its own; this is a separate named
+ * event because Sabilytics builds journeys from custom events, not pageviews.
+ *
+ * Guarded against firing twice: React runs effects twice in development, and a
+ * duplicate here would inflate the top of the funnel and quietly understate
+ * every conversion rate measured against it.
+ */
+export function TicketsPageView() {
+  const fired = useRef(false);
+
+  useEffect(() => {
+    if (fired.current) return;
+    fired.current = true;
+    trackTicketsPageViewed();
+  }, []);
+
+  return null;
+}

--- a/lib/sabilytics.ts
+++ b/lib/sabilytics.ts
@@ -9,6 +9,10 @@ declare global {
   interface Window {
     sabilytics?: {
       track: (event: string, data?: Record<string, unknown>) => void;
+      /** Returns sb_vid, sb_sid and utm_* as a query string. */
+      handoffParams?: () => string;
+      /** Merges those onto a URL, so a purchase off-site can be joined back. */
+      appendHandoffParams?: (url: string) => string;
     };
   }
 }
@@ -16,6 +20,20 @@ declare global {
 export const SABILYTICS_SRC = "https://www.sabilytics.com/script.js";
 export const SABILYTICS_SITE_ID = "1csn36flwfzz";
 export const SABILYTICS_DOMAIN = "blockfestafrica.com";
+
+/**
+ * Conversion event names.
+ *
+ * These must match the goal and journey steps configured in Sabilytics
+ * exactly, so they live here rather than as loose strings at each call site.
+ * snake_case is the house style there.
+ */
+export const EVENTS = {
+  /** Journey step: someone reached the page where passes are chosen. */
+  ticketsPageViewed: "tickets_page_viewed",
+  /** Journey step: someone left for the ticket platform. */
+  ticketCheckoutStarted: "ticket_checkout_started",
+} as const;
 
 /** Fire a custom event. Safe to call before the script loads. */
 export function track(event: string, data?: Record<string, unknown>): void {
@@ -32,9 +50,40 @@ export function trackButtonClick(name: string, location?: string): void {
   track("button-click", { name, ...(location ? { location } : {}) });
 }
 
-/** Someone headed for the ticket platform. `source` matches the UTM content. */
-export function trackTicketIntent(source: string): void {
-  track("ticket-intent", { source });
+/** Someone reached /tickets. The first step of the funnel. */
+export function trackTicketsPageViewed(): void {
+  track(EVENTS.ticketsPageViewed);
+}
+
+/**
+ * Someone headed for the ticket platform.
+ *
+ * `source` is the placement, and matches the utm_content on the link so the
+ * click and the campaign row line up. `pass` is the tier when a specific one
+ * was chosen, which is what makes BRIDGE PASS comparable to ALL ACCESS.
+ */
+export function trackCheckoutStarted(source: string, pass?: string): void {
+  track(EVENTS.ticketCheckoutStarted, {
+    source,
+    ...(pass ? { pass } : {}),
+  });
+}
+
+/**
+ * Add the visitor and session ids to an outbound ticket link.
+ *
+ * Returns the url untouched when the script has not loaded, so a blocked or
+ * slow tracker costs attribution and never a broken link. The url already
+ * carries UTMs from ticketUrl(); this adds the identity that would let a
+ * purchase completed off-site be joined back to the visit that started it.
+ */
+export function withHandoff(url: string): string {
+  if (typeof window === "undefined") return url;
+  try {
+    return window.sabilytics?.appendHandoffParams?.(url) ?? url;
+  } catch {
+    return url;
+  }
 }
 
 /** Strip absolute paths and query strings out of a stack before sending it. */


### PR DESCRIPTION
Everything that does not depend on Meetumo. Ships and works the day it merges.

## What now fires

| Event | When | Props |
|---|---|---|
| `tickets_page_viewed` | someone reaches `/tickets` | — |
| `ticket_checkout_started` | someone leaves for the ticket platform | `source`, `pass` |

Both verified against a real build:

```
landing on /tickets      -> tickets_page_viewed
click Get BRIDGE PASS    -> ticket_checkout_started { source: "Tickets Page - BRIDGE PASS", pass: "bridge-pass" }
click Get ALL ACCESS     -> ticket_checkout_started { source: "Tickets Page - ALL ACCESS PASS", pass: "all-access" }
```

`tickets_page_viewed` is guarded against React's double effect in development — a duplicate there would inflate the top of the funnel and quietly understate every rate measured against it.

## Outbound links now carry identity

Links pick up `sb_vid` and `sb_sid` via `appendHandoffParams`, so a purchase completed off-site could be joined back **if Meetumo ever exposes a way to** (it cannot today — see #below).

The href is still **server-rendered with plain UTMs**, so a visitor with JavaScript off or the tracker blocked gets a working link. Verified with JS disabled: the link is intact. Identity is added in place on `pointerdown` and `focus` — mouse, touch and keyboard — rather than via `preventDefault` and a re-open, which keeps `target="_blank"` out of popup-blocker territory and preserves middle-click and open-in-new-tab.

## ⚠️ Found while verifying: the vendor's guidance contradicts itself

`appendHandoffParams` **prefers the inbound URL's UTMs over the ones already on the link.** Measured with the real tracker:

| visitor | BRIDGE PASS `utm_content` | ALL ACCESS `utm_content` | passes distinguishable? |
|---|---|---|---|
| direct | `tickets-page-bridge-pass` | `tickets-page-all-access-pass` | **yes** |
| from an IG campaign | `ig-reel` | `ig-reel` | **no** |

So the moment someone arrives from a campaign that sets `utm_content`, every pass button hands off with the same value. That is **correct for campaign attribution and wrong for pass comparison** — and it directly contradicts Sabilytics' own advice to "use one `utm_content` per pass button".

Mitigated: **pass-level comparison lives in the `pass` event prop**, which is unaffected. Worth raising with Sabilytics, since their doc tells you to do something their tracker then undoes.

## Cleanup

The old `ticket-intent` event is gone. Its only caller was the homepage hero — on a `<Link href="/tickets">`, an **internal navigation, not a checkout start**. Counting it would have corrupted the funnel from day one. Four other files imported the helper and never called it.

## Add these in Sabilytics

Conversions → Add goal. Event names must match exactly:

- Journey step: **`tickets_page_viewed`**
- Journey step: **`ticket_checkout_started`**
- Goal: **`ticket_purchased`** — nothing fires this yet; it needs Phase 2

## What this does and does not tell you

**Does:** traffic to `/tickets` by campaign, click-through rate to the platform by campaign, and which pass CTAs get pressed.

**Does not:** whether anyone paid. Until Phase 2, "clicked through" is the success measure — a proxy, not a sale. Someone who abandons at payment looks identical to a buyer. Worth saying plainly to whoever reads the dashboard.

## Verification

57 pages, 134/134 tests, tsc and biome clean, all routes 200. Events asserted with the tracker stubbed; handoff and UTM precedence measured against the live tracker; the no-JS fallback confirmed with JavaScript disabled.