### PR TITLE
feat: receive Meetumo ticket webhooks and forward them as conversions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,15 @@ NEXT_PUBLIC_SITE_URL=https://blockfestafrica.com
 # Web analytics — Sabilytics. Site id and domain are public and live in
 # lib/sabilytics.ts, so there is nothing to configure here.
 
+# Meetumo -> Sabilytics conversion webhook.
+# MEETUMO_WEBHOOK_SECRET is the whsec_... value Meetumo shows ONCE when the
+# webhook endpoint is created; there is no way to read it back afterwards.
+# SABILYTICS_WRITE_KEY comes from Conversions -> Set up tracking -> Server.
+# Both are server-only. Never prefix them with NEXT_PUBLIC_: that would ship
+# them to the browser and let anyone post conversions as us.
+MEETUMO_WEBHOOK_SECRET=
+SABILYTICS_WRITE_KEY=
+
 # Analytics Dashboard — the password gating /insights
 INSIGHTS_PASSWORD=your-insights-password
 

--- a/__tests__/unit/meetumo.test.ts
+++ b/__tests__/unit/meetumo.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for the Meetumo webhook.
+ *
+ * This endpoint is public and takes money-shaped data from the internet, so
+ * the signature check is the only thing standing between a stranger and our
+ * revenue numbers. It is tested harder than anything else here.
+ */
+
+import { createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  EVENT_MAP,
+  toConversion,
+  verifySignature,
+} from "@/lib/meetumo";
+
+const SECRET = "whsec_test_secret_value";
+
+function sign(payload: string, timestamp: number, secret = SECRET) {
+  return createHmac("sha256", secret).update(`${timestamp}.${payload}`).digest("hex");
+}
+
+function purchase(data: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    id: "whd_abc123",
+    event: "ticket.purchased",
+    timestamp: 1735700000000,
+    data: {
+      orderId: "ord_9",
+      ticketTier: "BRIDGE PASS",
+      quantity: 2,
+      amount: 15000,
+      currency: "NGN",
+      attendeeEmail: "buyer@example.com",
+      ...data,
+    },
+  });
+}
+
+describe("verifySignature", () => {
+  const now = 1735700000000;
+
+  it("accepts a correctly signed payload", () => {
+    const body = purchase();
+    const r = verifySignature({
+      payload: body,
+      signature: sign(body, now),
+      timestamp: String(now),
+      secret: SECRET,
+      now,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects a payload signed with the wrong secret", () => {
+    const body = purchase();
+    const r = verifySignature({
+      payload: body,
+      signature: sign(body, now, "whsec_not_our_secret"),
+      timestamp: String(now),
+      secret: SECRET,
+      now,
+    });
+    expect(r).toEqual({ ok: false, reason: "signature mismatch" });
+  });
+
+  it("rejects a payload whose body was altered after signing", () => {
+    // The exact attack the signature exists to stop: a real delivery replayed
+    // with the amount inflated.
+    const original = purchase({ amount: 15000 });
+    const signature = sign(original, now);
+    const tampered = purchase({ amount: 999999 });
+    const r = verifySignature({
+      payload: tampered,
+      signature,
+      timestamp: String(now),
+      secret: SECRET,
+      now,
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects when the timestamp is not the one that was signed", () => {
+    const body = purchase();
+    const r = verifySignature({
+      payload: body,
+      signature: sign(body, now),
+      timestamp: String(now + 1000),
+      secret: SECRET,
+      now,
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a replay older than five minutes", () => {
+    const old = now - 6 * 60 * 1000;
+    const body = purchase();
+    const r = verifySignature({
+      payload: body,
+      signature: sign(body, old),
+      timestamp: String(old),
+      secret: SECRET,
+      now,
+    });
+    expect(r).toEqual({ ok: false, reason: "timestamp too old" });
+  });
+
+  it("accepts one just inside the five minute window", () => {
+    const recent = now - 4 * 60 * 1000;
+    const body = purchase();
+    const r = verifySignature({
+      payload: body,
+      signature: sign(body, recent),
+      timestamp: String(recent),
+      secret: SECRET,
+      now,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects a timestamp from the future", () => {
+    const future = now + 10 * 60 * 1000;
+    const body = purchase();
+    const r = verifySignature({
+      payload: body,
+      signature: sign(body, future),
+      timestamp: String(future),
+      secret: SECRET,
+      now,
+    });
+    expect(r).toEqual({ ok: false, reason: "timestamp in future" });
+  });
+
+  it("rejects missing or unparseable headers rather than throwing", () => {
+    const body = purchase();
+    expect(
+      verifySignature({ payload: body, signature: null, timestamp: String(now), secret: SECRET, now })
+    ).toEqual({ ok: false, reason: "missing signature" });
+    expect(
+      verifySignature({ payload: body, signature: sign(body, now), timestamp: null, secret: SECRET, now })
+    ).toEqual({ ok: false, reason: "missing timestamp" });
+    expect(
+      verifySignature({ payload: body, signature: sign(body, now), timestamp: "not-a-number", secret: SECRET, now })
+    ).toEqual({ ok: false, reason: "unparseable timestamp" });
+  });
+
+  it("does not throw on a signature of the wrong length", () => {
+    // timingSafeEqual throws when buffers differ in length; a short signature
+    // must be a rejection, not a 500.
+    const body = purchase();
+    expect(() =>
+      verifySignature({ payload: body, signature: "abc", timestamp: String(now), secret: SECRET, now })
+    ).not.toThrow();
+    expect(
+      verifySignature({ payload: body, signature: "abc", timestamp: String(now), secret: SECRET, now }).ok
+    ).toBe(false);
+  });
+});
+
+describe("toConversion", () => {
+  it("maps a purchase to the goal event with money attached", () => {
+    const c = toConversion(JSON.parse(purchase()));
+    expect(c?.eventName).toBe("ticket_purchased");
+    expect(c?.props).toMatchObject({
+      pass: "BRIDGE PASS",
+      quantity: 2,
+      value: 15000,
+      currency: "NGN",
+      order_id: "ord_9",
+    });
+  });
+
+  it("uses the delivery id as the idempotency key, so retries cannot double count", () => {
+    const c = toConversion(JSON.parse(purchase()));
+    expect(c?.idempotencyKey).toBe("whd_abc123");
+  });
+
+  it("falls back to an event-scoped key when there is no delivery id", () => {
+    const env = JSON.parse(purchase());
+    delete env.id;
+    const c = toConversion(env);
+    // Scoped by event so a refund of an order cannot collide with its purchase.
+    expect(c?.idempotencyKey).toBe("ticket_purchased:ord_9");
+  });
+
+  it("still records the sale when the amount field is named something else", () => {
+    // The ticket.purchased shape is undocumented, so missing money must not
+    // discard the conversion.
+    const env = JSON.parse(purchase());
+    delete env.data.amount;
+    const c = toConversion(env);
+    expect(c?.eventName).toBe("ticket_purchased");
+    expect(c?.props.value).toBeUndefined();
+    expect(c?.props.order_id).toBe("ord_9");
+  });
+
+  it("reads alternative field names for amount and tier", () => {
+    const c = toConversion({
+      id: "whd_1",
+      event: "ticket.purchased",
+      data: { totalAmount: "26250", tierName: "BECOME PASS", currencyCode: "NGN" },
+    });
+    expect(c?.props).toMatchObject({ value: 26250, pass: "BECOME PASS", currency: "NGN" });
+  });
+
+  it("defaults currency to NGN, which is what the site prices in", () => {
+    const env = JSON.parse(purchase());
+    delete env.data.currency;
+    expect(toConversion(env)?.props.currency).toBe("NGN");
+  });
+
+  it("keeps money off events where no money moved", () => {
+    const c = toConversion({ id: "whd_2", event: "ticket.checked_in", data: { amount: 15000 } });
+    expect(c?.eventName).toBe("ticket_checked_in");
+    expect(c?.props.value).toBeUndefined();
+    expect(c?.props.currency).toBeUndefined();
+  });
+
+  it("gives refunds their own event so they are not counted as sales", () => {
+    expect(toConversion({ id: "a", event: "ticket.refunded", data: {} })?.eventName)
+      .toBe("ticket_refunded");
+    expect(toConversion({ id: "b", event: "ticket.partially_refunded", data: {} })?.eventName)
+      .toBe("ticket_partially_refunded");
+    expect(toConversion({ id: "c", event: "ticket.cancelled", data: {} })?.eventName)
+      .toBe("ticket_cancelled");
+  });
+
+  it("ignores the events we do not subscribe to", () => {
+    for (const event of ["event.published", "community.member.joined", "lead.captured", "broadcast.sent"]) {
+      expect(toConversion({ id: "x", event, data: {} })).toBeNull();
+    }
+    expect(toConversion({})).toBeNull();
+  });
+
+  it("emits only flat primitives, which is all Sabilytics accepts", () => {
+    const c = toConversion(JSON.parse(purchase({ nested: { a: 1 }, list: [1, 2] })));
+    for (const value of Object.values(c?.props ?? {})) {
+      expect(["string", "number", "boolean"]).toContain(typeof value);
+    }
+  });
+
+  it("does not forward the buyer's personal details", () => {
+    const c = toConversion(JSON.parse(purchase()));
+    const serialised = JSON.stringify(c?.props);
+    expect(serialised).not.toContain("buyer@example.com");
+    expect(serialised.toLowerCase()).not.toContain("email");
+  });
+
+  it("uses snake_case names within the 64 character limit", () => {
+    for (const name of Object.values(EVENT_MAP)) {
+      expect(name).toMatch(/^[a-z0-9_]+$/);
+      expect(name.length).toBeLessThanOrEqual(64);
+    }
+  });
+});

--- a/app/api/webhooks/meetumo/route.ts
+++ b/app/api/webhooks/meetumo/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import {
+  EVENT_MAP,
+  forwardConversion,
+  toConversion,
+  verifySignature,
+  type MeetumoEnvelope,
+} from "@/lib/meetumo";
+
+/**
+ * POST /api/webhooks/meetumo
+ *
+ * Ticket sales complete on Meetumo and Paystack, so this is the only way a
+ * purchase reaches our analytics. Register the endpoint in Meetumo against the
+ * six ticket.* events; everything else it sends is acknowledged and dropped.
+ *
+ * Runs on Node rather than the edge because signature verification needs
+ * node:crypto, and dynamic because a webhook must never be cached or
+ * prerendered.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const SECRET = process.env.MEETUMO_WEBHOOK_SECRET;
+const WRITE_KEY = process.env.SABILYTICS_WRITE_KEY;
+
+export async function POST(request: Request) {
+  if (!SECRET || !WRITE_KEY) {
+    // Fail loudly in logs but quietly to the caller: an unconfigured endpoint
+    // should not look like a valid one to anybody probing it.
+    console.error(
+      "[meetumo] not configured:",
+      !SECRET ? "MEETUMO_WEBHOOK_SECRET missing" : "SABILYTICS_WRITE_KEY missing"
+    );
+    return NextResponse.json({ error: "not configured" }, { status: 503 });
+  }
+
+  // The raw body, byte for byte. Parsing first would break the signature.
+  const payload = await request.text();
+
+  const verified = verifySignature({
+    payload,
+    signature:
+      request.headers.get("x-meetumo-signature") ??
+      request.headers.get("x-jekapade-signature"),
+    timestamp:
+      request.headers.get("x-meetumo-timestamp") ??
+      request.headers.get("x-jekapade-timestamp"),
+    secret: SECRET,
+  });
+
+  if (!verified.ok) {
+    console.warn("[meetumo] rejected:", verified.reason);
+    return NextResponse.json({ error: "invalid signature" }, { status: 401 });
+  }
+
+  let envelope: MeetumoEnvelope;
+  try {
+    envelope = JSON.parse(payload) as MeetumoEnvelope;
+  } catch {
+    // Signed but unparseable. Retrying will not help, so accept and move on.
+    console.warn("[meetumo] signed payload was not JSON");
+    return NextResponse.json({ received: true }, { status: 200 });
+  }
+
+  const conversion = toConversion(envelope);
+  if (!conversion) {
+    // One of the 40+ event types we did not subscribe to, or an unmapped one.
+    return NextResponse.json(
+      { received: true, ignored: envelope.event ?? null },
+      { status: 200 }
+    );
+  }
+
+  /**
+   * The field names inside `data` are undocumented for ticket events, so log
+   * the KEYS on the first purchases to confirm the mapping in lib/meetumo.ts
+   * is reading the right ones. Keys only: the values carry buyer names and
+   * email addresses and have no business in a log.
+   */
+  if (conversion.eventName === "ticket_purchased") {
+    console.info(
+      "[meetumo] ticket.purchased data keys:",
+      Object.keys(envelope.data ?? {}).join(", ") || "(none)",
+      "| mapped props:",
+      Object.keys(conversion.props).join(", ") || "(none)"
+    );
+  }
+
+  const forwarded = await forwardConversion(conversion, WRITE_KEY);
+
+  if (!forwarded.ok) {
+    // Return non-2xx so Meetumo retries. The idempotency key means a duplicate
+    // delivery cannot double-count the sale.
+    console.error(
+      "[meetumo] forward failed:",
+      forwarded.status,
+      forwarded.body ?? ""
+    );
+    return NextResponse.json({ error: "forward failed" }, { status: 502 });
+  }
+
+  return NextResponse.json({ received: true }, { status: 200 });
+}
+
+/** A GET is useful for confirming the route is deployed and configured. */
+export function GET() {
+  return NextResponse.json({
+    endpoint: "meetumo webhook",
+    configured: Boolean(SECRET && WRITE_KEY),
+    subscribes: Object.keys(EVENT_MAP),
+  });
+}

--- a/lib/meetumo.ts
+++ b/lib/meetumo.ts
@@ -1,0 +1,237 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Meetumo webhooks, and how they become Sabilytics conversions.
+ *
+ * Payment happens on Meetumo and then Paystack, so the site never sees the
+ * purchase. This is the only path by which a sale reaches our analytics.
+ *
+ * One thing to be clear about, because it shapes everything here: Meetumo
+ * cannot tell us which campaign produced a sale. Their checkout sends a closed
+ * set of fields and the argument validator rejects anything else, the Paystack
+ * URL is generated server-side, and no part of their app reads the utm_* or
+ * sb_vid params we attach to the outbound link. So conversions are posted
+ * without a visitorId and land as direct. Revenue and volume are real; the
+ * campaign breakdown is not available until Meetumo exposes either the
+ * posthogDistinctId already on their order, or a metadata passthrough.
+ */
+
+/** Signatures older than this are rejected, per Meetumo's own guidance. */
+const MAX_AGE_MS = 5 * 60 * 1000;
+
+/** Meetumo wants a response inside 5s, so leave room to answer after this. */
+export const FORWARD_TIMEOUT_MS = 3500;
+
+/** Overridable only so the route can be exercised against a local receiver. */
+export const SABILYTICS_CONVERSIONS_URL =
+  process.env.SABILYTICS_CONVERSIONS_URL ??
+  "https://www.sabilytics.com/api/v1/conversions";
+
+/**
+ * Ticket events we act on, and the Sabilytics event each becomes.
+ *
+ * Only ticket_purchased is the goal. The rest are posted under their own names
+ * so refunds and cancellations are visible without being counted as sales.
+ * Meetumo sends 40+ event types; anything not listed is acknowledged and
+ * ignored rather than forwarded.
+ */
+export const EVENT_MAP: Record<string, string> = {
+  "ticket.purchased": "ticket_purchased",
+  "ticket.refunded": "ticket_refunded",
+  "ticket.partially_refunded": "ticket_partially_refunded",
+  "ticket.cancelled": "ticket_cancelled",
+  "ticket.transferred": "ticket_transferred",
+  "ticket.checked_in": "ticket_checked_in",
+};
+
+export interface MeetumoEnvelope {
+  id?: string;
+  event?: string;
+  timestamp?: number;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Verify a Meetumo signature.
+ *
+ * HMAC-SHA256 over `timestamp.payload`, compared in constant time. Returns a
+ * reason rather than a bare false so a rejection can be diagnosed from logs
+ * without echoing the signature back to the caller.
+ */
+export function verifySignature({
+  payload,
+  signature,
+  timestamp,
+  secret,
+  now = Date.now(),
+}: {
+  payload: string;
+  signature: string | null;
+  timestamp: string | null;
+  secret: string;
+  now?: number;
+}): { ok: true } | { ok: false; reason: string } {
+  if (!signature) return { ok: false, reason: "missing signature" };
+  if (!timestamp) return { ok: false, reason: "missing timestamp" };
+
+  const ts = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(ts)) return { ok: false, reason: "unparseable timestamp" };
+  if (ts < now - MAX_AGE_MS) return { ok: false, reason: "timestamp too old" };
+  // A timestamp from the future is as suspect as one from the past.
+  if (ts > now + MAX_AGE_MS) return { ok: false, reason: "timestamp in future" };
+
+  const expected = createHmac("sha256", secret)
+    .update(`${timestamp}.${payload}`)
+    .digest("hex");
+
+  const given = Buffer.from(signature, "utf8");
+  const want = Buffer.from(expected, "utf8");
+  // timingSafeEqual throws on a length mismatch, which is itself a leak of
+  // sorts, so compare lengths first and return the same generic reason.
+  if (given.length !== want.length) return { ok: false, reason: "signature mismatch" };
+  if (!timingSafeEqual(given, want)) return { ok: false, reason: "signature mismatch" };
+
+  return { ok: true };
+}
+
+/** Read a number from any of several candidate keys. */
+function pickNumber(
+  source: Record<string, unknown>,
+  keys: string[]
+): number | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim() !== "") {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return undefined;
+}
+
+/** Read a non-empty string from any of several candidate keys. */
+function pickString(
+  source: Record<string, unknown>,
+  keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string" && value.trim() !== "") return value.trim();
+  }
+  return undefined;
+}
+
+export interface ConversionPayload {
+  eventName: string;
+  props: Record<string, string | number | boolean | null>;
+  idempotencyKey: string;
+}
+
+/**
+ * Turn a verified envelope into something Sabilytics accepts.
+ *
+ * Meetumo publishes a payload example for community.member.joined only, never
+ * for ticket.purchased, so the field names for amount, currency and tier are
+ * not documented. Rather than guess one name and silently record nothing, each
+ * value is read from a list of plausible keys and simply omitted when absent:
+ * a conversion without a value is still a sale, and dropping the whole event
+ * because a price could not be found would be worse. Correct the lists below
+ * once a real payload has been seen.
+ *
+ * Amounts are assumed to be major units. If Meetumo sends kobo, revenue will
+ * read 100x high, which is exactly the sort of thing the first live purchase
+ * should be checked for.
+ */
+export function toConversion(
+  envelope: MeetumoEnvelope
+): ConversionPayload | null {
+  const eventName = envelope.event ? EVENT_MAP[envelope.event] : undefined;
+  if (!eventName) return null;
+
+  const data = (envelope.data ?? {}) as Record<string, unknown>;
+
+  const props: Record<string, string | number | boolean | null> = {};
+
+  const pass = pickString(data, [
+    "ticketTier",
+    "tierName",
+    "ticket_type",
+    "ticketType",
+    "tier",
+  ]);
+  if (pass) props.pass = pass;
+
+  const quantity = pickNumber(data, ["quantity", "ticketCount", "count"]);
+  if (quantity !== undefined) props.quantity = quantity;
+
+  // Money only belongs on the events where money moved.
+  if (eventName === "ticket_purchased" || eventName.includes("refunded")) {
+    const value = pickNumber(data, [
+      "amount",
+      "total",
+      "totalAmount",
+      "amountPaid",
+      "price",
+    ]);
+    if (value !== undefined) props.value = value;
+
+    const currency = pickString(data, ["currency", "currencyCode"]);
+    props.currency = currency ?? "NGN";
+  }
+
+  const orderId = pickString(data, ["orderId", "order_id", "id", "ticketId"]);
+  if (orderId) props.order_id = orderId;
+
+  return {
+    eventName,
+    props,
+    /**
+     * Meetumo retries, so every delivery must be safe to replay. Their
+     * delivery id is unique per attempt-set and is the right key; the order id
+     * is the fallback, and the two are combined so a refund of an order cannot
+     * collide with its purchase.
+     */
+    idempotencyKey: envelope.id ?? `${eventName}:${orderId ?? "unknown"}`,
+  };
+}
+
+/**
+ * Send a conversion to Sabilytics.
+ *
+ * No visitorId is sent, because Meetumo does not carry one. The call is
+ * bounded so a slow analytics endpoint cannot push us past the 5s Meetumo
+ * allows for a response.
+ */
+export async function forwardConversion(
+  conversion: ConversionPayload,
+  writeKey: string,
+  timeoutMs = FORWARD_TIMEOUT_MS
+): Promise<{ ok: boolean; status: number; body?: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(SABILYTICS_CONVERSIONS_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${writeKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(conversion),
+      signal: controller.signal,
+    });
+    return {
+      ok: res.ok,
+      status: res.status,
+      body: res.ok ? undefined : (await res.text()).slice(0, 300),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      body: error instanceof Error ? error.message : "forward failed",
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
Phase two. Payment completes on Meetumo and then Paystack, so the site never sees a sale; this endpoint is the only path by which one reaches our analytics. It runs as a Netlify function from the existing Next runtime, so there is no new infrastructure.

Signature verification is the whole security boundary, since the endpoint is public and takes money-shaped data from the internet. HMAC-SHA256 over `timestamp.payload`, compared in constant time, rejecting anything older or newer than five minutes. Lengths are compared before timingSafeEqual, which throws on a mismatch rather than returning false. Exercised against a running build: a delivery replayed with the amount inflated to 9,999,999 is rejected, as are a wrong secret, a missing signature and a seven-minute-old replay.

Only ticket_purchased is the goal. Refunds, cancellations and transfers post under their own names so they are visible without being counted as sales. The other 40+ event types Meetumo can send are acknowledged and dropped.

Retries are safe. Meetumo's delivery id is the idempotency key, falling back to event:order so a refund cannot collide with the purchase it reverses. A failed forward returns 502 rather than 200, so Meetumo retries rather than dropping the sale.

The buyer's email is in the payload Meetumo sends and is not forwarded.

Two things are honestly unverified, and the code says so rather than pretending otherwise. Meetumo documents a payload for community.member.joined only, never for ticket.purchased, so the field names for amount, currency and tier are guesses: each is read from a list of candidates and omitted when absent, because a sale with no price recorded still beats dropping the sale. The route logs the data KEYS of the first purchases, never the values, so the first real delivery corrects the mapping. And amounts are assumed to be major units; if Meetumo sends kobo, revenue reads 100x high.

Conversions carry no visitorId, because Meetumo cannot supply one. They will land as direct until Meetumo exposes the posthogDistinctId already on their order, or adds a metadata passthrough.