### PR TITLE
feat: open the call for speakers

### DIFF
--- a/app/call-for-speakers/page.tsx
+++ b/app/call-for-speakers/page.tsx
@@ -8,15 +8,22 @@ import {
   sessionFormats,
   speakerTerms,
   speakingDays,
+  speakingDayShape,
 } from "@/lib/speaking";
 import { SpeakerApplyCTA } from "@/components/speakers/apply-cta";
 import { CURRENT_EDITION, EVENT_ID, SITE_URL } from "@/lib/seo-event";
 
 const EVENT = CURRENT_EDITION;
 
+const OG_TITLE = "Call for Speakers | Blockf3st Africa '26 Lagos";
+// Counts come from the data so the share card cannot drift from the page body.
+const OG_DESCRIPTION = `Pitch a session for ${EVENT.name}. ${lagos2026Tracks.length} tracks, ${sessionFormats.length} formats, 2 days in Lagos.`;
+
 export const metadata: Metadata = {
-  title: "Call for Speakers | Blockf3st Africa '26 Lagos",
-  description: `Speaker applications for ${EVENT.name}, ${EVENT.date.displayDate}. Keynotes, panels, fireside chats, lightning talks and hands-on workshops across six tracks spanning AI, blockchain, policy, capital, infrastructure, culture and careers.`,
+  // The root layout appends "| Blockf3st Africa 2026", so branding here would
+  // be the third copy in one title tag.
+  title: "Call for Speakers",
+  description: `Speaker applications for ${EVENT.name}, ${EVENT.date.displayDate}. Workshops and masterclasses on day one, panels and lightning talks on day two, across ${lagos2026Tracks.length} tracks spanning AI, blockchain, policy, capital, infrastructure, culture and careers.`,
   keywords: [
     "blockfest africa call for speakers",
     "speak at blockfest",
@@ -24,9 +31,27 @@ export const metadata: Metadata = {
     "web3 ai speaker application lagos",
     "call for papers africa tech",
   ],
+  // Next replaces these objects wholesale rather than merging them into the
+  // layout's, so the image and url have to be restated or the card ships bare.
   openGraph: {
-    title: "Call for Speakers | Blockf3st Africa '26 Lagos",
-    description: `Pitch a session for ${EVENT.name}. Six tracks, six formats, two days in Lagos.`,
+    type: "website",
+    url: `${SITE_URL}/call-for-speakers`,
+    title: OG_TITLE,
+    description: OG_DESCRIPTION,
+    images: [
+      {
+        url: `${SITE_URL}/images/og-speakers.jpg`,
+        width: 1200,
+        height: 630,
+        alt: `Call for speakers — ${EVENT.name}`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: OG_TITLE,
+    description: OG_DESCRIPTION,
+    images: [`${SITE_URL}/images/twitter-speakers.jpg`],
   },
   alternates: { canonical: `${SITE_URL}/call-for-speakers` },
 };
@@ -34,10 +59,10 @@ export const metadata: Metadata = {
 /**
  * The call for speakers.
  *
- * Written to be read before the form exists. Last year's application asked for
- * a headshot, a bio, a 100 to 200 word session description and a line on how
- * the topic meets the theme, all in one sitting — so this page says that up
- * front, and the apply control announces itself rather than pretending to work.
+ * Written to be read before the form, not instead of it. The application runs
+ * seven pages and asks for a bio, a session description, key takeaways and a
+ * case for why you are the one to give it — so this page puts that list in
+ * front of the button rather than behind it.
  */
 export default function CallForSpeakersPage() {
   return (
@@ -93,9 +118,10 @@ export default function CallForSpeakersPage() {
               </div>
             </div>
 
-            {/* The form asks for a bio, a headshot and a written session
-                description in one sitting. The apply control sits at the foot
-                of the page so a reader meets that list before the button. */}
+            {/* The form asks for a bio, a session description, key takeaways
+                and a case for delivering it. The apply control sits at the
+                foot of the page so a reader meets that list before the
+                button. */}
             <div className="mt-8">
               <a
                 href="#formats"
@@ -109,19 +135,49 @@ export default function CallForSpeakersPage() {
         </section>
 
         {/* ---------- Formats ---------- */}
+        {/* scroll-mt clears the sticky navbar, which would otherwise sit on
+            top of the heading this link jumps to. Matches the FAQ anchors. */}
         <section
           id="formats"
-          className="section-y bg-ground border-t border-white/20"
+          className="section-y bg-ground scroll-mt-24 border-t border-white/20"
         >
           <div className="container-page">
             <h2 className="text-display-sm font-bold text-white">
-              {sessionFormats.length} formats
+              {sessionFormats.length} formats, across two days
             </h2>
             <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
-              Pick the one that fits the idea, not the one that sounds most
-              senior. A sharp seven minutes is often worth more than a keynote
+              Each day has its own shape, and each format belongs to one of
+              them. Pick the one that fits the idea, not the one that sounds
+              most senior. A sharp seven minutes is often worth more than a talk
               stretched to fill its slot, and a workshop people leave having
               built something beats both.
+            </p>
+
+            {/* The day picker and the format picker are separate questions on
+                the form, but the answers constrain each other. Showing the two
+                days first means the format cards below read as a choice within
+                a day rather than a flat list of four unrelated options. */}
+            <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2">
+              {speakingDayShape.map((day) => (
+                <div
+                  key={day.label}
+                  className="rounded-xl border border-white/20 bg-white/5 p-6"
+                >
+                  <div className="flex flex-wrap items-baseline gap-x-3">
+                    <h3 className="text-lg font-bold text-white">
+                      {day.label}
+                    </h3>
+                    <span className="eyebrow text-brand-gold">{day.time}</span>
+                  </div>
+                  <p className="mt-2 text-sm leading-relaxed text-white/60">
+                    {day.detail}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <p className="mt-6 max-w-2xl text-base leading-relaxed text-white/60">
+              You can also apply as open to either day.
             </p>
 
             <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2">
@@ -156,8 +212,12 @@ export default function CallForSpeakersPage() {
             <h2 className="text-display-sm font-bold text-white">
               {lagos2026Tracks.length} tracks
             </h2>
+            {/* Deliberately does not claim the form's track question offers
+                these exact six labels — it groups them differently, and
+                naming its options here would go stale the moment it changes. */}
             <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
-              The application asks which one your session belongs to. If it sits
+              The programme runs on these six. The application asks you to place
+              your session, and lets you pick more than one, so if it sits
               across two, say so and say why.
             </p>
 
@@ -186,14 +246,18 @@ export default function CallForSpeakersPage() {
               Have these ready
             </h2>
             <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
-              The form asks for all of it in one sitting, and there is no saving
-              halfway. Twenty minutes gathering this first is the difference
-              between a considered application and an abandoned one.
+              The form needs a Google account and saves a draft as you go, so
+              you can leave and come back. The writing is the slow part, though,
+              and twenty minutes gathering this first is the difference between
+              a considered application and an abandoned one.
             </p>
 
-            <div className="mt-8 flex flex-col gap-4">
+            {/* An ordered list, because it is one: these follow the order the
+                form asks in. The rendered ordinals are decorative — the list
+                element itself carries the numbering for assistive tech. */}
+            <ol className="mt-8 flex list-none flex-col gap-4">
               {applicationChecklist.map((item, index) => (
-                <div
+                <li
                   key={item.title}
                   className="flex items-start gap-5 rounded-xl border border-white/20 bg-white/5 p-5 sm:p-6"
                 >
@@ -211,9 +275,9 @@ export default function CallForSpeakersPage() {
                       {item.detail}
                     </p>
                   </div>
-                </div>
+                </li>
               ))}
-            </div>
+            </ol>
           </div>
         </section>
 
@@ -224,8 +288,8 @@ export default function CallForSpeakersPage() {
               Before you apply
             </h2>
             <p className="mt-4 max-w-2xl text-base leading-relaxed text-white/60">
-              The form asks you to agree to each of these, so none of it should
-              be a surprise when you get there.
+              {speakerTerms.length} consent questions close the form. None of it
+              should be a surprise by the time you get there.
             </p>
 
             <ul className="mt-8 columns-1 gap-x-10 lg:columns-2">
@@ -260,7 +324,7 @@ export default function CallForSpeakersPage() {
               <p className="mt-4 text-base leading-relaxed text-white/60">
                 {isSpeakerFormOpen
                   ? "Sessions are selected on the strength of the idea and the fit with the programme, not on follower count."
-                  : "The form is not live yet. Get what is above ready now and you will be able to submit in one sitting when it opens. We announce it on X first."}
+                  : "The form is not live yet. Get what is above ready now and you will be able to move quickly when it opens. We announce it on X first."}
               </p>
 
               <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-6">

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -11,7 +11,11 @@ import {
 } from "@/lib/tickets";
 import { SITE_URL } from "@/lib/seo-event";
 import { volunteerTeams } from "@/lib/volunteer";
-import { isSpeakerFormOpen } from "@/lib/speaking";
+import {
+  isSpeakerFormOpen,
+  sessionFormats,
+  SPEAKER_FORM_URL,
+} from "@/lib/speaking";
 
 /**
  * /llms.txt — a plain-text brief for AI clients and agents.
@@ -79,8 +83,10 @@ export function GET() {
 - Volunteering: applications are open across ${volunteerTeams.length} departments for
   22 and 23 October. Roles, what each team does and the application form are at
   ${SITE_URL}/volunteer
-- Speaking: the call for speakers is at ${SITE_URL}/call-for-speakers. Four session
-  formats across ${lagos2026Tracks.length} tracks. ${isSpeakerFormOpen ? "Applications are open." : "The application form is not open yet."}
+- Speaking: the call for speakers is at ${SITE_URL}/call-for-speakers.
+  ${sessionFormats.length} session formats across ${lagos2026Tracks.length} tracks. Workshops and
+  masterclasses run on 22 October, panels and lightning talks on 23 October.
+  ${isSpeakerFormOpen ? `Applications are open; the form is at ${SPEAKER_FORM_URL}.` : "The application form is not open yet."}
 
 ## Tickets
 
@@ -99,6 +105,8 @@ ${TICKET_PLATFORM_URL} is the official ticket platform.
 - ${SITE_URL}/tickets: all ${ticketTiers.length} passes, prices and inclusions
 - ${SITE_URL}/faq: pricing, refunds, meals, transport, accessibility
 - ${SITE_URL}/speakers: past speakers; the ${e.year} lineup is announced in the coming weeks
+- ${SITE_URL}/call-for-speakers: session formats, tracks and what the speaker application asks for
+- ${SITE_URL}/volunteer: volunteer departments, roles and the application form
 - ${SITE_URL}/schedule: the ${past.year} programme; the ${e.year} schedule is published in the coming weeks
 - ${SITE_URL}/blockfest-2025: recap of ${past.name}
 - ${SITE_URL}/blockfest-south-africa-2026: recap of the Cape Town roadshow, May 2026

--- a/app/speakers/page.tsx
+++ b/app/speakers/page.tsx
@@ -5,12 +5,14 @@ import { SpeakersSchema } from "@/components/seo/speakers-schema";
 import { BreadcrumbSchema } from "@/components/seo/schema-markup";
 import { SpeakersList, type Speaker } from "@/lib/speakers";
 import { ComingSoonNotice } from "@/components/shared/coming-soon-notice";
+import { isSpeakerFormOpen } from "@/lib/speaking";
 import { gotham } from "@/lib/fonts";
 
 export const metadata: Metadata = {
   title: "Speakers",
-  description:
-    "The Lagos '26 speaker lineup is announced in the coming weeks. Meet the blockchain pioneers, AI builders, founders and investors who have spoken at Blockfest Africa.",
+  description: isSpeakerFormOpen
+    ? "The Lagos '26 speaker lineup is announced in the coming weeks, and the call for speakers is open until then. Meet the blockchain pioneers, AI builders, founders and investors who have spoken at Blockfest Africa."
+    : "The Lagos '26 speaker lineup is announced in the coming weeks. Meet the blockchain pioneers, AI builders, founders and investors who have spoken at Blockfest Africa.",
   keywords: [
     "blockfest africa speakers",
     "blockchain experts africa",
@@ -78,9 +80,21 @@ const SpeakersPage = () => {
       <BreadcrumbSchema items={breadcrumbItems} />
 
       <main id="main" className={gotham.className}>
+        {/* The lineup is unannounced because the programme is still being
+            selected — which makes this the one page where "coming soon" has a
+            better call to action than a ticket: you could be on it. */}
         <ComingSoonNotice
           title="2026 lineup coming soon"
-          description="Lagos '26 speakers are announced in the coming weeks. Below, the voices who have graced our stage."
+          description={
+            isSpeakerFormOpen
+              ? "Lagos '26 speakers are announced in the coming weeks, and the call for speakers is open until then. Below, the voices who have graced our stage."
+              : "Lagos '26 speakers are announced in the coming weeks. Below, the voices who have graced our stage."
+          }
+          action={
+            isSpeakerFormOpen
+              ? { href: "/call-for-speakers", label: "Apply to speak" }
+              : undefined
+          }
         />
         <SpeakersGrid />
       </main>

--- a/app/travel/page.tsx
+++ b/app/travel/page.tsx
@@ -173,15 +173,21 @@ export default function TravelPage() {
                   Read the FAQ
                 </Link>
               </div>
-              <p className="mt-6 flex items-center gap-2 text-sm text-white/60">
-                <Mail className="h-4 w-4 shrink-0" aria-hidden="true" />
-                Anything not answered here:{" "}
-                <a
-                  href={`mailto:${CONTACT_EMAIL}`}
-                  className="text-link underline underline-offset-2 hover:text-white"
-                >
-                  {CONTACT_EMAIL}
-                </a>
+              {/* Same shape as the volunteer page: the sentence is a single
+                  flex item so the address wraps as prose instead of being
+                  squeezed into its own column. items-start because a wrapped
+                  line should not push the icon to the vertical middle. */}
+              <p className="mt-6 flex items-start gap-2 text-sm text-white/60">
+                <Mail className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+                <span>
+                  Anything not answered here:{" "}
+                  <a
+                    href={`mailto:${CONTACT_EMAIL}`}
+                    className="break-words text-link underline underline-offset-2 hover:text-white"
+                  >
+                    {CONTACT_EMAIL}
+                  </a>
+                </span>
               </p>
             </div>
           </div>

--- a/app/volunteer/page.tsx
+++ b/app/volunteer/page.tsx
@@ -136,16 +136,21 @@ export default function VolunteerPage() {
               ))}
             </div>
 
+            {/* The sentence is one flex item, not three. Left unwrapped, the
+                icon, the label and the link each become their own column and
+                the link gets squeezed to a few characters wide on a phone. */}
             <p className="mt-6 flex items-start gap-2 text-sm text-white/60">
               <MapPin className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-              Travelling in?{" "}
-              <Link
-                href="/travel"
-                className="text-link underline underline-offset-2 hover:text-white"
-              >
-                Getting to Lagos
-              </Link>{" "}
-              covers the venue, accommodation and moving around the city.
+              <span>
+                Travelling in?{" "}
+                <Link
+                  href="/travel"
+                  className="text-link underline underline-offset-2 hover:text-white"
+                >
+                  Getting to Lagos
+                </Link>{" "}
+                covers the venue, accommodation and moving around the city.
+              </span>
             </p>
           </div>
         </section>

--- a/components/shared/coming-soon-notice.tsx
+++ b/components/shared/coming-soon-notice.tsx
@@ -6,10 +6,20 @@ interface ComingSoonNoticeProps {
   title: string;
   /** One line on what is on the page in the meantime. */
   description: string;
+  /**
+   * Where the banner sends you. Defaults to tickets, which is the right answer
+   * on most pages — but a page whose content is missing *because* something is
+   * still open has a better one to offer, so it can say so.
+   */
+  action?: { href: string; label: string };
 }
 
 /** Banner for pages showing last year's content while this year's is prepared. */
-export function ComingSoonNotice({ title, description }: ComingSoonNoticeProps) {
+export function ComingSoonNotice({
+  title,
+  description,
+  action = { href: "/tickets", label: "Get your ticket" },
+}: ComingSoonNoticeProps) {
   return (
     <div className="border-b border-gray-200 bg-paper-muted">
       <div className="container-page flex flex-col items-start gap-4 py-5 sm:flex-row sm:items-center sm:justify-between">
@@ -24,10 +34,10 @@ export function ComingSoonNotice({ title, description }: ComingSoonNoticeProps) 
           <p className="mt-1 text-sm text-gray-600">{description}</p>
         </div>
         <Link
-          href="/tickets"
+          href={action.href}
           className="inline-flex min-h-11 shrink-0 items-center gap-2 rounded-full bg-brand-blue px-6 py-3 text-sm font-semibold text-white transition-colors duration-300 hover:bg-brand-blue-dark"
         >
-          Get your ticket
+          {action.label}
           <ArrowRight className="h-4 w-4" aria-hidden="true" />
         </Link>
       </div>

--- a/components/speakers/apply-cta.tsx
+++ b/components/speakers/apply-cta.tsx
@@ -31,6 +31,9 @@ export function SpeakerApplyCTA({
         className={`${base} ${className}`}
       >
         {children}
+        {/* The arrow signals the new tab to sighted users; this says the same
+            thing to a screen reader, which cannot see it. */}
+        <span className="sr-only"> (opens in a new tab)</span>
         <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
       </a>
     );

--- a/lib/faq-data.ts
+++ b/lib/faq-data.ts
@@ -1,3 +1,5 @@
+import { isSpeakerFormOpen } from "@/lib/speaking";
+
 export interface FAQItem {
   id: number;
   question: string;
@@ -191,8 +193,14 @@ export const faqData: FAQItem[] = [
   {
     id: 19,
     question: "Can I speak at Blockf3st Africa 2026?",
-    answer:
-      "Speaker applications open in the coming weeks. Follow us on social media to be notified. We are looking for industry experts, founders and thought leaders across AI and Web3.",
+    // Driven off the same switch as the rest of the site. This answer is
+    // rendered on /faq, in the homepage FAQ and inside the FAQPage JSON-LD, so
+    // hardcoding it once meant telling Google applications were shut while the
+    // form was live. Plain text, not markup: the answer is emitted into the
+    // structured data verbatim and rendered as a text node.
+    answer: isSpeakerFormOpen
+      ? "Yes. The call for speakers is open. The session formats, the tracks and everything the application asks for are at blockfestafrica.com/call-for-speakers, and you can apply from there. We are looking for industry experts, founders and thought leaders across AI and Web3."
+      : "Speaker applications open in the coming weeks. Follow us on social media to be notified. We are looking for industry experts, founders and thought leaders across AI and Web3.",
     category: "Community & Support",
   },
 ];

--- a/lib/speaking.ts
+++ b/lib/speaking.ts
@@ -3,11 +3,13 @@ import { blockfest2026Lagos } from "./events";
 /**
  * The call for speakers.
  *
- * The form is not open yet. `SPEAKER_FORM_URL` is the only switch: set it and
- * the page stops saying "opening soon" and starts linking, everywhere at once.
- * Nothing else needs editing.
+ * `SPEAKER_FORM_URL` is the only switch: set it and the page stops saying
+ * "opening soon" and starts linking, everywhere at once. Everything else in
+ * this file mirrors what the live form actually asks, so the page can be read
+ * as preparation for it rather than a summary written from memory.
  */
-export const SPEAKER_FORM_URL: string | null = null;
+export const SPEAKER_FORM_URL: string | null =
+  "https://forms.gle/i6JJJXToKLHVixHFA";
 
 export const isSpeakerFormOpen = SPEAKER_FORM_URL !== null;
 
@@ -19,82 +21,118 @@ export interface SessionFormat {
   description: string;
 }
 
-/** The formats the application asks you to pick between. */
+/**
+ * The formats the application asks you to pick between.
+ *
+ * Each is bound to a day on the form itself — the hands-on formats run on day
+ * one, the stage formats on day two — so the day is carried in the label
+ * rather than left for the applicant to work out.
+ */
 export const sessionFormats: SessionFormat[] = [
   {
-    name: "Keynote",
-    length: "Main stage",
+    name: "Workshop",
+    length: "Day 1 · 60 min",
     description:
-      "One person, one argument, the room's full attention. For a thesis you have earned the right to make.",
+      "Hands-on, participatory, activity-driven. People leave having built or practised something rather than having watched you do it. Bring the repo, the dataset, the contract or the worksheet.",
+  },
+  {
+    name: "Masterclass",
+    length: "Day 1 · 20 min + 10 min Q&A",
+    description:
+      "An expert-led deep dive with structured questions at the end. Best for a method you have refined and can genuinely teach in one sitting.",
   },
   {
     name: "Panel discussion",
-    length: "Moderated",
+    length: "Day 2 · 45–60 min",
     description:
-      "Three or four voices on a question that genuinely divides them. Bring the disagreement, not the consensus.",
-  },
-  {
-    name: "Fireside chat",
-    length: "Conversational",
-    description:
-      "A longer, less formal conversation. Best when the story behind the work is the interesting part.",
+      "Several voices on a question that genuinely divides them, with a moderator. Bring the disagreement, not the consensus.",
   },
   {
     name: "Lightning talk",
-    length: "Under 7 minutes",
+    length: "Day 2 · 7–10 min",
     description:
-      "One idea, sharply made, no room to warm up. Often the most memorable thing on a programme.",
-  },
-  {
-    name: "Technical workshop",
-    length: "Day 1, hands on",
-    description:
-      "People leave having built something. Bring the repo, the dataset or the contract, and expect a room that wants to follow along rather than watch.",
-  },
-  {
-    name: "Non-technical workshop",
-    length: "Day 1, hands on",
-    description:
-      "The same shape without the terminal. Fundraising, go to market, design, policy, storytelling: anything people can practise in the room and use on Monday.",
+      "One speaker, one idea, sharply made, no room to warm up. Often the most memorable thing on a programme.",
   },
 ];
 
-/** Prepared in advance, because the form asks for all of it in one sitting. */
+/**
+ * What the form asks for, in the order it asks.
+ *
+ * Google Forms keeps a draft, so this is not a one-sitting sprint — but the
+ * writing is the slow part and it is easier done before you open the form.
+ */
 export const applicationChecklist = [
+  {
+    title: "Who you are, and where to find you",
+    detail:
+      "Full name, email, phone number with country code, company, job title, and the city and country you live in. Plus your LinkedIn or personal site and your X handle.",
+  },
+  {
+    title: "The day and the format",
+    detail:
+      "Which day you are applying for — day one, day two, or open to either — and which of the four formats fits. The formats are tied to days, so these two answers move together.",
+  },
   {
     title: "A session title and description",
     detail:
-      "100 to 200 words on what you will actually say. Specific beats broad: a talk about one thing you have done lands better than a survey of a field.",
+      "100 to 300 words on what attendees will actually learn or do. Specific beats broad: a session about one thing you have done lands better than a survey of a field.",
   },
   {
-    title: "Your bio",
-    detail: "100 to 150 words, written in the third person.",
-  },
-  {
-    title: "A recent professional headshot",
+    title: "Two or three key takeaways",
     detail:
-      "Used on the site and in promotion if you are selected, so send the one you would be happy to see on a banner.",
-  },
-  {
-    title: "Your links",
-    detail:
-      "LinkedIn or a personal site, and your X handle. Plus one to three events you have spoken at, with the topic and year, if you have them.",
+      "What people leave with. This is the question that separates a talk with a point from a talk with a topic, so it is worth drafting before the description.",
   },
   {
     title: "Who it is for",
     detail:
-      "Which audiences the session serves, and which track it belongs to. Both are on the form.",
+      "Which audiences the session serves — developers, creatives, founders, policy and legal, investors, marketers, newcomers — and whether it assumes no prior Web3 knowledge, some, or a room of practitioners.",
+  },
+  {
+    title: "Your bio and your case",
+    detail:
+      "A bio of up to 200 words in the third person, a short answer on why you are the right person to deliver this session, and one to three events you have spoken at with the topic, year and links.",
+  },
+  {
+    title: "Logistics",
+    detail:
+      "What you need in the room — projector, microphone, high-capacity WiFi for a workshop, a live coding or demo environment — whether you are Lagos-based, travelling in or joining virtually, and whether you can cover your own travel and accommodation.",
+  },
+  {
+    title: "Why Blockfest, and one last yes or no",
+    detail:
+      "A short paragraph on why you want to speak at Blockfest Africa in particular — a different question from why you are the right person for the session — and whether you are willing to do a short video interview after the event.",
   },
 ];
 
-/** Stated plainly, because all four are consent questions on the form. */
+/** Stated plainly, because all four are consent questions at the end of the form. */
 export const speakerTerms = [
   "Applying does not guarantee a speaking slot.",
-  `If selected, your name, bio, session title and headshot may be used on the site, in promotional material and on social media.`,
-  "Sessions are recorded and photographed, and may be published or shared online afterwards.",
+  "If selected, your name, bio and session title may be used on the site, in promotional material and on social media.",
+  "Sessions may be recorded and photographed, and published or shared online afterwards.",
   "The team will contact you by email or phone about your application, and about logistics if you are selected.",
-  "The form asks whether you can cover your own travel and accommodation if you are coming from outside Lagos.",
 ];
 
-/** Both days carry sessions, so a proposal can be for either. */
-export const speakingDays = `${EVENT.date.displayDate.replace(/,\s*\d{4}$/, "")}, ${EVENT.location.venue}`;
+/** Sessions run on the first two days; the third is the invite-only Mixer. */
+export const speakingDays = `Two days of sessions on 22 and 23 October at the ${EVENT.location.venue}`;
+
+/**
+ * Shape of each day, as the form describes it when you pick one.
+ *
+ * Day two is described by the formats you can actually apply for. The form's
+ * own blurb also mentions fireside chats, but its format question does not
+ * offer them, and this text sits directly above those four cards.
+ */
+export const speakingDayShape = [
+  {
+    label: "Day 1",
+    time: "9am – 2pm",
+    detail:
+      "Workshops and masterclasses. Hands-on, skills-first sessions for founders, builders, creators and marketers.",
+  },
+  {
+    label: "Day 2",
+    time: "9am – 5pm",
+    detail:
+      "The main conference. Panels and lightning talks in front of the full audience.",
+  },
+];


### PR DESCRIPTION
The form is live at https://forms.gle/i6JJJXToKLHVixHFA, so `SPEAKER_FORM_URL` is set and every apply control across the site becomes a real link.

## The page didn't match the form

`app/call-for-speakers` was written ahead of the form, against last year's application. The live one differs, so the data it renders from is corrected:

| | Page said | Form actually |
|---|---|---|
| Formats | 6 — incl. keynote, fireside chat, technical/non-technical workshops | 4 — Workshop (60m), Masterclass (20+10), Panel (45–60m), Lightning talk (7–10m), each bound to a day |
| Headshot | "have a recent professional headshot ready" | Never requested |
| Description | 100–200 words | 100–300 words |
| Bio | 100–150 words | max 200 words |
| Saving | "no saving halfway" | Keeps a draft |
| Dates | Oct 22–24 | Sessions are the 22nd and 23rd; the 24th is the invite-only Mixer |

The checklist also gained the questions it was missing outright: key takeaways, why you're the right person, audience segments and experience level, AV needs, travel, and the separate "why Blockfest" paragraph on page six.

## Opened the door where people look

- **FAQ item 19** still told readers — and Google's FAQ rich result — that applications hadn't opened. It was the one place hardcoded rather than driven by `isSpeakerFormOpen`. Now it reads off the same switch.
- **`/speakers`** banner pointed at tickets. The lineup is unannounced precisely because selection is still open, so it now points at the call for speakers. `ComingSoonNotice` takes an optional `action` for this.
- **`llms.txt`** serves the form URL and lists the route in its page index.

## Fixed while checking the above

- Title was branded three times (`Call for Speakers | Blockf3st Africa '26 Lagos | Blockf3st Africa 2026`) — the root layout already appends the site name.
- A page-level `openGraph` object **replaces** the layout's rather than merging, so this page's share card shipped with no image and no url. Restated both, added a `twitter` block, and derived the counts from the data so the card can't drift from the body again.
- `#formats` jump target sat under the sticky navbar.
- The prepare-for-it steps are an ordered list, not divs with `aria-hidden` numbers.
- The apply link opens a new tab without telling a screen reader.

## Testing

`tsc --noEmit`, `eslint` (3 pre-existing `<img>` warnings only), 134/134 tests, and `next build` all pass.

Off state verified too: with `SPEAKER_FORM_URL` set back to `null`, the build carries no form links anywhere and the FAQ and `llms.txt` both fall back to "not open yet". The single-switch design still holds end to end.

## Two things in the form itself

Not code, but worth a look before this gets traffic:

1. **The track list contradicts itself.** The intro blurb names six tracks matching the site; the actual track question offers a different five plus Other (Founders & Capital, Web3 Developers & Builders, AI, Creators & Monetisation, Careers & Entry Paths). Applicants read one list and pick from another. The page deliberately no longer claims the form uses these exact six labels.
2. **The intro promises keynotes and fireside chats**, neither of which is selectable in the format question.

Separately: the form states the theme as "The New Trade Routes: Taking Africa OnChain"; the site says "New Trade Routes: Bringing Africa Onchain". Left alone — it's the brand line, it appears in the hero and in generated OG images, and which one is canonical is your call, not mine.